### PR TITLE
Supply crates 2

### DIFF
--- a/code/game/objects/items/devices/geiger_counter.dm
+++ b/code/game/objects/items/devices/geiger_counter.dm
@@ -19,7 +19,7 @@
 	var/grace = RAD_GEIGER_GRACE_PERIOD
 	var/datum/looping_sound/geiger/soundloop
 
-	var/scanning = FALSE
+	var/scanning = TRUE
 	var/radiation_count = 0
 	var/current_tick_amount = 0
 	var/last_tick_amount = 0

--- a/code/game/objects/items/dna_injector.dm
+++ b/code/game/objects/items/dna_injector.dm
@@ -78,7 +78,7 @@
 	desc += " This one is spent, you better recycle it!"
 
 
-/obj/item/dnainjector/antihulk
+/obj/item/dnainjector/anti/hulk
 	name = "\improper DNA injector (Anti-Hulk)"
 	desc = "Cures green skin."
 	remove_mutations = list(HULK)
@@ -93,13 +93,13 @@
 	desc = "Finally you can see what the Captain does."
 	add_mutations = list(XRAY)
 
-/obj/item/dnainjector/antixray
+/obj/item/dnainjector/anti/xray
 	name = "\improper DNA injector (Anti-X-ray)"
 	desc = "It will make you see harder."
 	remove_mutations = list(XRAY)
 
 /////////////////////////////////////
-/obj/item/dnainjector/antiglasses
+/obj/item/dnainjector/anti/glasses
 	name = "\improper DNA injector (Anti-Glasses)"
 	desc = "Toss away those glasses!"
 	remove_mutations = list(BADSIGHT)
@@ -114,12 +114,12 @@
 	desc = "Shake shake shake the room!"
 	add_mutations = list(EPILEPSY)
 
-/obj/item/dnainjector/antiepi
+/obj/item/dnainjector/anti/epi
 	name = "\improper DNA injector (Anti-Epi.)"
 	desc = "Will fix you up from shaking the room."
 	remove_mutations = list(EPILEPSY)
 ////////////////////////////////////
-/obj/item/dnainjector/anticough
+/obj/item/dnainjector/anti/cough
 	name = "\improper DNA injector (Anti-Cough)"
 	desc = "Will stop that awful noise."
 	remove_mutations = list(COUGH)
@@ -129,7 +129,7 @@
 	desc = "Will bring forth a sound of horror from your throat."
 	add_mutations = list(COUGH)
 
-/obj/item/dnainjector/antidwarf
+/obj/item/dnainjector/anti/dwarf
 	name = "\improper DNA injector (Anti-Dwarfism)"
 	desc = "Helps you grow big and strong."
 	remove_mutations = list(DWARFISM)
@@ -144,7 +144,7 @@
 	desc = "Makes clown minions."
 	add_mutations = list(CLOWNMUT)
 
-/obj/item/dnainjector/anticlumsy
+/obj/item/dnainjector/anti/clumsy
 	name = "\improper DNA injector (Anti-Clumsy)"
 	desc = "Apply this for Security Clown."
 	remove_mutations = list(CLOWNMUT)
@@ -154,12 +154,12 @@
 	desc = "This is your last chance to turn back."
 	add_mutations = list(CLOWNMUT)
 
-/obj/item/dnainjector/anticluwne
+/obj/item/dnainjector/anti/cluwne
 	name = "\improper DNA injector (Anti-Cluwne)"
 	desc = "This isn't going to work."
 	remove_mutations = list(CLOWNMUT)
 
-/obj/item/dnainjector/antitour
+/obj/item/dnainjector/anti/tour
 	name = "\improper DNA injector (Anti-Tour.)"
 	desc = "Will cure Tourette's."
 	remove_mutations = list(TOURETTES)
@@ -174,12 +174,12 @@
 	desc = "Makes you s-s-stuttterrr."
 	add_mutations = list(NERVOUS)
 
-/obj/item/dnainjector/antistutt
+/obj/item/dnainjector/anti/stutt
 	name = "\improper DNA injector (Anti-Stutt.)"
 	desc = "Fixes that speaking impairment."
 	remove_mutations = list(NERVOUS)
 
-/obj/item/dnainjector/antifire
+/obj/item/dnainjector/anti/fire
 	name = "\improper DNA injector (Anti-Fire)"
 	desc = "Cures fire."
 	remove_mutations = list(SPACEMUT)
@@ -194,12 +194,12 @@
 	desc = "Makes you not see anything."
 	add_mutations = list(BLINDMUT)
 
-/obj/item/dnainjector/antiblind
+/obj/item/dnainjector/anti/blind
 	name = "\improper DNA injector (Anti-Blind)"
 	desc = "IT'S A MIRACLE!!!"
 	remove_mutations = list(BLINDMUT)
 
-/obj/item/dnainjector/antitele
+/obj/item/dnainjector/anti/tele
 	name = "\improper DNA injector (Anti-Tele.)"
 	desc = "Will make you not able to control your mind."
 	remove_mutations = list(TK)
@@ -218,7 +218,7 @@
 	desc = "Sorry, what did you say?"
 	add_mutations = list(DEAFMUT)
 
-/obj/item/dnainjector/antideaf
+/obj/item/dnainjector/anti/deaf
 	name = "\improper DNA injector (Anti-Deaf)"
 	desc = "Will make you hear once more."
 	remove_mutations = list(DEAFMUT)
@@ -233,7 +233,7 @@
 	desc = "Will make you...less hairy."
 	remove_mutations = list(RACEMUT)
 
-/obj/item/dnainjector/antichameleon
+/obj/item/dnainjector/anti/chameleon
 	name = "\improper DNA injector (Anti-Chameleon)"
 	remove_mutations = list(CHAMELEON)
 
@@ -241,7 +241,7 @@
 	name = "\improper DNA injector (Chameleon)"
 	add_mutations = list(CHAMELEON)
 
-/obj/item/dnainjector/antiwacky
+/obj/item/dnainjector/anti/wacky
 	name = "\improper DNA injector (Anti-Wacky)"
 	remove_mutations = list(WACKY)
 
@@ -249,7 +249,7 @@
 	name = "\improper DNA injector (Wacky)"
 	add_mutations = list(WACKY)
 
-/obj/item/dnainjector/antimute
+/obj/item/dnainjector/anti/mute
 	name = "\improper DNA injector (Anti-Mute)"
 	remove_mutations = list(MUT_MUTE)
 
@@ -257,7 +257,7 @@
 	name = "\improper DNA injector (Mute)"
 	add_mutations = list(MUT_MUTE)
 
-/obj/item/dnainjector/antismile
+/obj/item/dnainjector/anti/smile
 	name = "\improper DNA injector (Anti-Smile)"
 	remove_mutations = list(SMILE)
 
@@ -269,7 +269,7 @@
 	name = "\improper DNA injector (Unintelligible)"
 	add_mutations = list(UNINTELLIGIBLE)
 
-/obj/item/dnainjector/antiunintelligible
+/obj/item/dnainjector/anti/unintelligible
 	name = "\improper DNA injector (Anti-Unintelligible)"
 	remove_mutations = list(UNINTELLIGIBLE)
 
@@ -277,7 +277,7 @@
 	name = "\improper DNA injector (Swedish)"
 	add_mutations = list(SWEDISH)
 
-/obj/item/dnainjector/antiswedish
+/obj/item/dnainjector/anti/swedish
 	name = "\improper DNA injector (Anti-Swedish)"
 	remove_mutations = list(SWEDISH)
 
@@ -285,7 +285,7 @@
 	name = "\improper DNA injector (Chav)"
 	add_mutations = list(CHAV)
 
-/obj/item/dnainjector/antichav
+/obj/item/dnainjector/anti/chav
 	name = "\improper DNA injector (Anti-Chav)"
 	remove_mutations = list(CHAV)
 
@@ -293,7 +293,7 @@
 	name = "\improper DNA injector (Elvis)"
 	add_mutations = list(ELVIS)
 
-/obj/item/dnainjector/antielvis
+/obj/item/dnainjector/anti/elvis
 	name = "\improper DNA injector (Anti-Elvis)"
 	remove_mutations = list(ELVIS)
 
@@ -301,7 +301,7 @@
 	name = "\improper DNA injector (Laser Eyes)"
 	add_mutations = list(LASEREYES)
 
-/obj/item/dnainjector/antilasereyes
+/obj/item/dnainjector/anti/lasereyes
 	name = "\improper DNA injector (Anti-Laser Eyes)"
 	remove_mutations = list(LASEREYES)
 
@@ -309,7 +309,7 @@
 	name = "\improper DNA injector (Void)"
 	add_mutations = list(VOID)
 
-/obj/item/dnainjector/antivoid
+/obj/item/dnainjector/anti/void
 	name = "\improper DNA injector (Anti-Void)"
 	remove_mutations = list(VOID)
 
@@ -317,7 +317,7 @@
 	name = "\improper DNA injector (Antenna)"
 	add_mutations = list(ANTENNA)
 
-/obj/item/dnainjector/antiantenna
+/obj/item/dnainjector/anti/antenna
 	name = "\improper DNA injector (Anti-Antenna)"
 	remove_mutations = list(ANTENNA)
 
@@ -325,7 +325,7 @@
 	name = "\improper DNA injector (Paranoia)"
 	add_mutations = list(PARANOIA)
 
-/obj/item/dnainjector/antiparanoia
+/obj/item/dnainjector/anti/paranoia
 	name = "\improper DNA injector (Anti-Paranoia)"
 	remove_mutations = list(PARANOIA)
 
@@ -333,14 +333,14 @@
 	name = "\improper DNA injector (Radioactive)"
 	add_mutations = list(RADIOACTIVE)
 
-/obj/item/dnainjector/antiradioactive
+/obj/item/dnainjector/anti/radioactive
 	name = "\improper DNA injector (Anti-Radioactive)"
 	remove_mutations = list(RADIOACTIVE)
 /obj/item/dnainjector/olfaction
 	name = "\improper DNA injector (Olfaction)"
 	add_mutations = list(OLFACTION)
 
-/obj/item/dnainjector/antiolfaction
+/obj/item/dnainjector/anti/olfaction
 	name = "\improper DNA injector (Anti-Olfaction)"
 	remove_mutations = list(OLFACTION)
 
@@ -348,7 +348,7 @@
 	name = "\improper DNA injector (Insulated)"
 	add_mutations = list(INSULATED)
 
-/obj/item/dnainjector/antiinsulated
+/obj/item/dnainjector/anti/insulated
 	name = "\improper DNA injector (Anti-Insulated)"
 	remove_mutations = list(INSULATED)
 
@@ -356,7 +356,7 @@
 	name = "\improper DNA injector (Shock Touch)"
 	add_mutations = list(SHOCKTOUCH)
 
-/obj/item/dnainjector/antishock
+/obj/item/dnainjector/anti/shock
 	name = "\improper DNA injector (Anti-Shock Touch)"
 	remove_mutations = list(SHOCKTOUCH)
 
@@ -364,7 +364,7 @@
 	name = "\improper DNA injector (Spatial Instability)"
 	add_mutations = list(BADBLINK)
 
-/obj/item/dnainjector/antispatialinstability
+/obj/item/dnainjector/anti/spatialinstability
 	name = "\improper DNA injector (Anti-Spatial Instability)"
 	remove_mutations = list(BADBLINK)
 
@@ -372,7 +372,7 @@
 	name = "\improper DNA injector (Acid Flesh)"
 	add_mutations = list(ACIDFLESH)
 
-/obj/item/dnainjector/antiacidflesh
+/obj/item/dnainjector/anti/acidflesh
 	name = "\improper DNA injector (Acid Flesh)"
 	remove_mutations = list(ACIDFLESH)
 
@@ -380,7 +380,7 @@
 	name = "\improper DNA injector (Gigantism)"
 	add_mutations = list(GIGANTISM)
 
-/obj/item/dnainjector/antigigantism
+/obj/item/dnainjector/anti/gigantism
 	name = "\improper DNA injector (Anti-Gigantism)"
 	remove_mutations = list(GIGANTISM)
 
@@ -388,7 +388,7 @@
 	name = "\improper DNA injector (Spastic)"
 	add_mutations = list(SPASTIC)
 
-/obj/item/dnainjector/antispastic
+/obj/item/dnainjector/anti/spastic
 	name = "\improper DNA injector (Anti-Spastic)"
 	remove_mutations = list(SPASTIC)
 
@@ -396,7 +396,7 @@
 	name = "\improper DNA injector (Two Left Feet)"
 	add_mutations = list(EXTRASTUN)
 
-/obj/item/dnainjector/antitwoleftfeet
+/obj/item/dnainjector/anti/twoleftfeet
 	name = "\improper DNA injector (Anti-Two Left Feet)"
 	remove_mutations = list(EXTRASTUN)
 
@@ -404,7 +404,7 @@
 	name = "\improper DNA injector (Geladikinesis)"
 	add_mutations = list(GELADIKINESIS)
 
-/obj/item/dnainjector/antigeladikinesis
+/obj/item/dnainjector/anti/geladikinesis
 	name = "\improper DNA injector (Anti-Geladikinesis)"
 	remove_mutations = list(GELADIKINESIS)
 
@@ -412,7 +412,7 @@
 	name = "\improper DNA injector (Cryokinesis)"
 	add_mutations = list(CRYOKINESIS)
 
-/obj/item/dnainjector/anticryokinesis
+/obj/item/dnainjector/anti/cryokinesis
 	name = "\improper DNA injector (Anti-Cryokinesis)"
 	remove_mutations = list(CRYOKINESIS)
 
@@ -420,7 +420,7 @@
 	name = "\improper DNA injector (Thermal Vision)"
 	add_mutations = list(THERMAL)
 
-/obj/item/dnainjector/antithermal
+/obj/item/dnainjector/anti/thermal
 	name = "\improper DNA injector (Anti-Thermal Vision)"
 	remove_mutations = list(THERMAL)
 
@@ -436,7 +436,7 @@
 	name = "\improper DNA injector (Antiglowy)"
 	add_mutations = list(ANTIGLOWY)
 
-/obj/item/dnainjector/removeantiglow
+/obj/item/dnainjector/anti/antiglow
 	name = "\improper DNA injector (Anti-Antiglowy)"
 	remove_mutations = list(ANTIGLOWY)
 
@@ -444,7 +444,7 @@
 	name = "\improper DNA injector (Strong Wings)"
 	add_mutations = list(STRONGWINGS)
 
-/obj/item/dnainjector/antistrongwings
+/obj/item/dnainjector/anti/strongwings
 	name = "\improper DNA injector (Anti-Strong Wings)"
 	remove_mutations = list(STRONGWINGS)
 
@@ -452,7 +452,7 @@
 	name = "\improper DNA injector (Cat Claws)"
 	add_mutations = list(CATCLAWS)
 
-/obj/item/dnainjector/anticatclaws
+/obj/item/dnainjector/anti/catclaws
 	name = "\improper DNA injector (Anti-Cat Claws)"
 	remove_mutations = list(CATCLAWS)
 
@@ -460,7 +460,7 @@
 	name = "\improper DNA injector (Overload)"
 	add_mutations = list(OVERLOAD)
 
-/obj/item/dnainjector/antioverload
+/obj/item/dnainjector/anti/overload
 	name = "\improper DNA injector (Anti-Overload)"
 	remove_mutations = list(OVERLOAD)
 
@@ -468,7 +468,7 @@
 	name = "\improper DNA injector (Acid Ooze)"
 	add_mutations = list(ACIDOOZE)
 
-/obj/item/dnainjector/antiacidooze
+/obj/item/dnainjector/anti/acidooze
 	name = "\improper DNA injector (Pepto-Bismol)"
 	remove_mutations = list(ACIDOOZE)
 
@@ -476,7 +476,7 @@
 	name = "\improper DNA injector (Medieval)"
 	add_mutations = list(MEDIEVAL)
 
-/obj/item/dnainjector/antimedieval
+/obj/item/dnainjector/anti/medieval
 	name = "\improper DNA injector (Anti-Medieval)"
 	remove_mutations = list(MEDIEVAL)
 

--- a/code/modules/admin/battle_royale.dm
+++ b/code/modules/admin/battle_royale.dm
@@ -8,9 +8,8 @@ GLOBAL_LIST_INIT(battle_royale_basic_loot, list(
 		/obj/item/gun/ballistic/shotgun/doublebarrel/improvised,
 		/obj/item/gun/ballistic/shotgun/doublebarrel/improvised/sawn,
 		/obj/item/reagent_containers/spray/flame,
-//		/obj/item/reagent_containers/spray/lube,
-//		/obj/item/reagent_containers/spray/acid,
-//		/obj/item/reagent_containers/spray/combo,
+		/obj/item/reagent_containers/spray/lube,
+		/obj/item/reagent_containers/spray/combo,
 		/obj/item/gun/energy/e_gun/mini/heads,
 		/obj/item/gun/energy/e_gun/mini,
 		/obj/item/gun/energy/disabler,
@@ -29,6 +28,7 @@ GLOBAL_LIST_INIT(battle_royale_basic_loot, list(
 		/obj/item/spear,
 		/obj/item/spear/bonespear,
 		/obj/item/spear/bamboospear,
+		/obj/item/storage/toolbox/mechanical/old/clean, //TC toolbox
 //Nullrods deemed suitable
 		/obj/item/nullrod/godhand,
 		/obj/item/nullrod/staff/blue,
@@ -42,7 +42,11 @@ GLOBAL_LIST_INIT(battle_royale_basic_loot, list(
 		/obj/item/nullrod/spear,
 //Shields
 		/obj/item/shield/energy,
-
+		/obj/item/shield/riot/roman,
+		/obj/item/shield/riot/buckler,
+		/obj/item/shield/riot/goliath,
+		/obj/item/shield/riot/flash,
+		/obj/item/shield/riot/tele,
 //Various armors, including duplicates for the sake of weight
 		/obj/item/clothing/suit/armor/riot,
 		/obj/item/clothing/suit/armor/vest,
@@ -97,46 +101,16 @@ GLOBAL_LIST_INIT(battle_royale_basic_loot, list(
 		/obj/item/clothing/shoes/clown_shoes/taeclowndo,
 		/obj/item/clothing/shoes/chameleon/noslip,
 		/obj/item/clothing/glasses/thermal/syndi,
-
-
-//Ammunition
-/*
-
-		/obj/item/ammo_box/a762 //mosin
-
-		/obj/item/ammo_box/magazine/m10mm //stechkin
-		/obj/item/ammo_box/magazine/m10mm/hp
-		/obj/item/ammo_box/magazine/m10mm/ap
-		/obj/item/ammo_box/magazine/m10mm/fire
-
-		/obj/item/storage/backpack/duffelbag/syndie/ammo/shotgun //shotgun
-		/obj/item/ammo_box/magazine/m12g
-		/obj/item/ammo_box/magazine/m12g/dragon
-		/obj/item/ammo_box/magazine/m12g/slug
-
-		/obj/item/ammo_box/a357			//Revolver
-		/obj/item/ammo_box/a357/match	
-
-		/obj/item/storage/backpack/duffelbag/syndie/ammo/smg //SMG
-		/obj/item/ammo_box/magazine/smgm45
-
-		/obj/item/ammo_box/magazine/sniper_rounds //Sniper
-		/obj/item/ammo_box/sniper
-		/obj/item/ammo_box/sniper/penetrator
-		/obj/item/ammo_box/sniper/soporific
-		/obj/item/ammo_casing/p50/emp
-		/obj/item/ammo_casing/p50/explosive
-		/obj/item/ammo_casing/p50/inferno
-
-		/obj/item/ammo_box/magazine/m556 //carbine
-
-		/obj/item/ammo_box/magazine/mm712x82 //L6 Saw HMG
-		/obj/item/ammo_box/magazine/mm712x82/ap
-		/obj/item/ammo_box/magazine/mm712x82/hollow
-		/obj/item/ammo_box/magazine/mm712x82/incen
-		/obj/item/ammo_box/magazine/mm712x82/match
-
-*/
+		/obj/item/clothing/shoes/galoshes,
+//Ammunition (Roughly 5% of crates)
+		/obj/item/storage/toolbox/ammo/royale,
+		/obj/item/storage/toolbox/ammo/royale,
+		/obj/item/storage/toolbox/ammo/royale,
+		/obj/item/storage/toolbox/ammo/royale,
+		/obj/item/storage/toolbox/ammo/royale,
+		/obj/item/storage/toolbox/ammo/royale,
+		/obj/item/storage/toolbox/ammo/royale,
+		/obj/item/storage/toolbox/ammo/royale,
 //Reagent warfare
 		/obj/item/gun/chem, //No syringes needed
 
@@ -168,14 +142,11 @@ GLOBAL_LIST_INIT(battle_royale_basic_loot, list(
 		/obj/item/stack/sheet/telecrystal/five,
 		/obj/item/stack/sheet/telecrystal/five,
 		/obj/item/stack/sheet/telecrystal/five,
-		
-
-
 //Medical supplies
 		/obj/item/reagent_containers/hypospray/medipen/stimulants,
 		/obj/item/storage/firstaid/tactical,
 		/obj/item/autosurgeon/syndicate/xray_eyes,
-
+		
 //Grenades
 		/obj/item/grenade/empgrenade,
 		/obj/item/grenade/chem_grenade/ez_clean, //acid foam
@@ -231,12 +202,16 @@ GLOBAL_LIST_INIT(battle_royale_good_loot, list(
 		/obj/item/gun/ballistic/shotgun/doublebarrel, //Lethal
 		/obj/item/gun/ballistic/shotgun/riot, //Non-lethal
 		/obj/item/gun/ballistic/shotgun/automatic/combat, //Very lethal
+		/obj/item/gun/ballistic/automatic/surplus,
+		/obj/item/gun/ballistic/automatic/surplus,
 		/obj/item/gun/ballistic/rifle/boltaction,
 		/obj/item/gun/ballistic/rifle/boltaction,
+		/obj/item/gun/ballistic/automatic/wt550,
+		/obj/item/gun/ballistic/automatic/wt550,
 		/obj/item/gun/ballistic/rocketlauncher,
 		/obj/item/gun/ballistic/revolver,
-		/obj/item/gun/ballistic/bow/clockwork,
 		/obj/item/gun/ballistic/revolver/mateba,
+		/obj/item/gun/ballistic/bow/clockwork,
 		/obj/item/gun/energy/laser,
 		/obj/item/gun/energy/e_gun,
 		/obj/item/gun/energy/e_gun,
@@ -244,7 +219,6 @@ GLOBAL_LIST_INIT(battle_royale_good_loot, list(
 		/obj/item/gun/energy/e_gun/old,
 		/obj/item/gun/energy/e_gun/hos,
 		/obj/item/gun/energy/e_gun/stun, //Basically just HoS gun again
-
 		/obj/item/pen/sleepy,
 		/obj/item/storage/box/syndie_kit/bundle_A,
 		/obj/item/storage/box/syndie_kit/bundle_B,
@@ -253,7 +227,6 @@ GLOBAL_LIST_INIT(battle_royale_good_loot, list(
 		/obj/vehicle/sealed/car/clowncar,
 		/obj/item/book/granter/spell/mimery_blockade,
 		/obj/item/book/granter/spell/mimery_guns,
-
 		/obj/item/gun/energy/kinetic_accelerator/crossbow/radbow,
 		/obj/item/pneumatic_cannon/pie/selfcharge,
 		/obj/item/shield/energy/bananium,
@@ -285,10 +258,11 @@ GLOBAL_LIST_INIT(battle_royale_insane_loot, list(
 //Still good, but not as good
 		/obj/item/storage/belt/grenade/full,
 		/obj/item/gun/ballistic/shotgun/bulldog,
-		/obj/item/gun/ballistic/automatic/c20r,
+		/obj/item/gun/ballistic/automatic/proto, // NT Saber SMG
+//		/obj/item/gun/ballistic/automatic/c20r,   //Included above as part of a bundle. Kept out of this pool to keep from diluting ammo pools
 		/obj/item/gun/ballistic/sniper_rifle/syndicate,
 		/obj/item/gun/ballistic/automatic/l6_saw,
-		/obj/item/gun/ballistic/automatic/m90,
+		/obj/item/gun/ballistic/automatic/m90, //As-is, with no additional ammo available after unloading to keep from diluting ammo pools
 		/obj/item/dualsaber,
 		/obj/item/guardiancreator/tech,
 		/obj/item/book/granter/martial/carp,

--- a/code/modules/admin/battle_royale.dm
+++ b/code/modules/admin/battle_royale.dm
@@ -224,11 +224,16 @@ GLOBAL_LIST_INIT(battle_royale_good_loot, list(
 		/obj/item/gun/energy/vortex,
 		/obj/item/gun/energy/xray,
 		//Megafauna/mining loot
-
+		/obj/structure/closet/crate/necropolis,
+		/obj/structure/closet/crate/necropolis,
+		/obj/structure/closet/crate/necropolis/random,
+		/obj/structure/closet/crate/necropolis/random,
 		//Various other items
 		/obj/item/storage/secure/briefcase/medgun_kit, //Random syringe gun and matching ammo. 50% syringe guns, 33% dna gun, 17% dart gun + bottles
 		/obj/item/storage/secure/briefcase/medgun_kit,
 		/obj/item/pen/sleepy,
+		/obj/item/storage/box/syndie_kit/bundle_A,
+		/obj/item/storage/box/syndie_kit/bundle_B,
 		/obj/item/storage/box/syndie_kit/bundle_A,
 		/obj/item/storage/box/syndie_kit/bundle_B,
 		/obj/item/storage/backpack/duffelbag/syndie/c4,

--- a/code/modules/admin/battle_royale.dm
+++ b/code/modules/admin/battle_royale.dm
@@ -112,29 +112,16 @@ GLOBAL_LIST_INIT(battle_royale_basic_loot, list(
 		/obj/item/storage/toolbox/ammo/royale,
 		/obj/item/storage/toolbox/ammo/royale,
 //Reagent warfare
-		/obj/item/gun/chem, //No syringes needed
-
+		/obj/item/storage/box/royale/assorted_syringes, //Random assortment of the four boxes below, with twice as many total syringes.
+		/obj/item/storage/box/royale/unlabeled_syringes, //contains completely unlabeled syringes containing CHEMICAL_RNG_FUN reagents
+		/obj/item/storage/box/royale/med_syringes, //contains unknown syringes identified only as "medicinal" which contain random /datum/reagent/medicine
+		/obj/item/storage/box/royale/tox_syringes, //contains unknown syringes identified only as "toxic" which contain random /datum/reagent/toxin
+		/obj/item/storage/box/royale/dna_syringes, //contains four random but correctly labeled dna injectors, excluding "anti" injectors
+		/obj/item/storage/box/syndie_kit/chemical, //really powerful assorted toxins, but no means of application included
 		/obj/item/storage/pill_bottle/floorpill/full,
 		/obj/item/reagent_containers/glass/bottle/romerol,
-		/obj/item/reagent_containers/hypospray/medipen/magillitis, //Gorilla transform
-/*
-	/obj/item/storage/box/syndie_kit/chemical
-
-	new /obj/item/reagent_containers/glass/bottle/polonium(src)
-	new /obj/item/reagent_containers/glass/bottle/venom(src)
-	new /obj/item/reagent_containers/glass/bottle/fentanyl(src)
-	new /obj/item/reagent_containers/glass/bottle/formaldehyde(src)
-	new /obj/item/reagent_containers/glass/bottle/spewium(src)
-	new /obj/item/reagent_containers/glass/bottle/cyanide(src)
-	new /obj/item/reagent_containers/glass/bottle/histamine(src)
-	new /obj/item/reagent_containers/glass/bottle/initropidril(src)
-	new /obj/item/reagent_containers/glass/bottle/pancuronium(src)
-	new /obj/item/reagent_containers/glass/bottle/sodium_thiopental(src)
-	new /obj/item/reagent_containers/glass/bottle/coniine(src)
-	new /obj/item/reagent_containers/glass/bottle/curare(src)
-	new /obj/item/reagent_containers/glass/bottle/amanitin(src)
-*/
-
+		/obj/item/reagent_containers/hypospray/medipen/magillitis, //Gorilla pen
+		/obj/item/reagent_containers/hypospray/medipen/snail, //Get snailed. Slow to work.
 //Uplink and crystals
 		/obj/item/storage/box/syndie_kit/imp_uplink, //0 TC, just the uplink
 		/obj/item/storage/box/syndie_kit/imp_uplink,
@@ -142,31 +129,49 @@ GLOBAL_LIST_INIT(battle_royale_basic_loot, list(
 		/obj/item/stack/sheet/telecrystal/five,
 		/obj/item/stack/sheet/telecrystal/five,
 		/obj/item/stack/sheet/telecrystal/five,
-//Medical supplies
+//Medical supplies and autosurgeons
+		/obj/item/reagent_containers/hypospray/medipen/survival,
+		/obj/item/reagent_containers/hypospray/medipen/survival,
 		/obj/item/reagent_containers/hypospray/medipen/stimulants,
 		/obj/item/storage/firstaid/tactical,
+		/obj/item/storage/firstaid/brute,
+		/obj/item/storage/firstaid/fire,
+		/obj/item/storage/firstaid/advanced,
 		/obj/item/autosurgeon/syndicate/xray_eyes,
-		
+		/obj/item/autosurgeon/syndicate/thermal_eyes,
+		/obj/item/autosurgeon/syndicate/reviver,
+		/obj/item/autosurgeon/cmo,
 //Grenades
 		/obj/item/grenade/empgrenade,
-		/obj/item/grenade/chem_grenade/ez_clean, //acid foam
-		/obj/item/grenade/clusterbuster/soap,
-		/obj/item/grenade/chem_grenade/teargas/moustache,
+		/obj/item/grenade/stingbang,
+		/obj/item/grenade/plastic/x4,
+		/obj/item/grenade/frag/mega,
+		/obj/item/grenade/gluon,
 		/obj/item/grenade/syndieminibomb,
 		/obj/item/grenade/discogrenade,
 		/obj/item/hot_potato/syndicate,
-
+		/obj/item/grenade/chem_grenade/ez_clean, //acid foam
+		/obj/item/grenade/chem_grenade/clf3, //lesser helfoam, still very fiery
+		/obj/item/grenade/chem_grenade/bioterrorfoam,
+		/obj/item/grenade/chem_grenade/holy,
+		/obj/item/grenade/chem_grenade/teargas/moustache,
+		/obj/item/grenade/clusterbuster,
+		/obj/item/grenade/clusterbuster/soap,
+		/obj/item/grenade/clusterbuster/emp,
+		/obj/item/grenade/clusterbuster/syndieminibomb,
+		/obj/item/grenade/clusterbuster/spawner_spesscarp,
 //Various consumables
 		/obj/item/book/granter/action/origami,
 		/obj/item/storage/box/syndie_kit/imp_microbomb,
 		/obj/item/storage/box/syndie_kit/imp_adrenal,
 		/obj/item/storage/box/syndie_kit/cultconstructkit,
 		/obj/item/toy/plush/carpplushie/dehy_carp,
+		/obj/item/reagent_containers/food/snacks/monkeycube/gorilla,
 		/obj/item/book/granter/martial/karate,
 		/obj/item/throwing_star,
 		/obj/item/restraints/legcuffs/bola/tactical,
 		/obj/item/book/granter/martial/tribal_claw,
-		/obj/item/reagent_containers/food/snacks/monkeycube/gorilla,
+		/obj/item/sharpener,
 		/obj/item/sharpener,
 //Misc
 		/obj/item/storage/briefcase/launchpad,
@@ -178,26 +183,17 @@ GLOBAL_LIST_INIT(battle_royale_basic_loot, list(
 		/obj/item/soap,
 		/obj/item/voodoo,
 		/obj/item/reverse_bear_trap,
-		/obj/item/toy/syndicateballoon/glued, //honk
-		
-
-
-
-/*
-	Some of the weaker syndicate kits
-	Single grenades and similar consumables
-	Sharpening stone
-*/
-	
-
-
+		/obj/item/toy/syndicateballoon/glued //honk
 	))
 
 GLOBAL_LIST_INIT(battle_royale_good_loot, list(
+		//Uplinks with varying TC
 		/obj/item/uplink/old, //10 TC
 		/obj/item/uplink, //20 TC
+		//Hostile turrets as a prank
 		/obj/machinery/porta_turret/syndicate/pod,
 		/obj/machinery/porta_turret/syndicate/energy/heavy, //Honk honk
+		//Ballistic guns
 		/obj/item/gun/ballistic/shotgun/lethal,
 		/obj/item/gun/ballistic/shotgun/doublebarrel, //Lethal
 		/obj/item/gun/ballistic/shotgun/riot, //Non-lethal
@@ -212,13 +208,26 @@ GLOBAL_LIST_INIT(battle_royale_good_loot, list(
 		/obj/item/gun/ballistic/revolver,
 		/obj/item/gun/ballistic/revolver/mateba,
 		/obj/item/gun/ballistic/bow/clockwork,
-		/obj/item/gun/energy/laser,
-		/obj/item/gun/energy/e_gun,
-		/obj/item/gun/energy/e_gun,
+		//Energy guns
 		/obj/item/gun/energy/e_gun/advtaser,
 		/obj/item/gun/energy/e_gun/old,
 		/obj/item/gun/energy/e_gun/hos,
 		/obj/item/gun/energy/e_gun/stun, //Basically just HoS gun again
+		/obj/item/gun/energy/laser/scatter,
+		/obj/item/gun/energy/laser/scatter/shotty,
+		/obj/item/gun/energy/laser/captain,
+		/obj/item/gun/energy/laser/captain/scattershot,
+		/obj/item/gun/energy/beam_rifle,
+		/obj/item/gun/energy/ionrifle,
+		/obj/item/gun/energy/ionrifle/carbine,
+		/obj/item/gun/energy/tesla_revolver,
+		/obj/item/gun/energy/vortex,
+		/obj/item/gun/energy/xray,
+		//Megafauna/mining loot
+
+		//Various other items
+		/obj/item/storage/secure/briefcase/medgun_kit, //Random syringe gun and matching ammo. 50% syringe guns, 33% dna gun, 17% dart gun + bottles
+		/obj/item/storage/secure/briefcase/medgun_kit,
 		/obj/item/pen/sleepy,
 		/obj/item/storage/box/syndie_kit/bundle_A,
 		/obj/item/storage/box/syndie_kit/bundle_B,
@@ -237,9 +246,6 @@ GLOBAL_LIST_INIT(battle_royale_good_loot, list(
 		/obj/item/clothing/gloves/krav_maga/combatglovesplus,
 		/obj/item/book/granter/martial/cqc,
 		/obj/item/hand_tele,
-
-		/obj/item/gun/energy/laser/captain,
-
 		/obj/item/katana,
 		/obj/item/fireaxe
 	))
@@ -255,6 +261,7 @@ GLOBAL_LIST_INIT(battle_royale_insane_loot, list(
 		/obj/item/reagent_containers/spray/chemsprayer/bioterror,
 		/obj/item/chainsaw/energy/doom,
 		/obj/mecha/combat/gygax/dark/loaded,
+		/obj/item/minigunpack,
 //Still good, but not as good
 		/obj/item/storage/belt/grenade/full,
 		/obj/item/gun/ballistic/shotgun/bulldog,

--- a/code/modules/admin/battle_royale.dm
+++ b/code/modules/admin/battle_royale.dm
@@ -160,6 +160,10 @@ GLOBAL_LIST_INIT(battle_royale_basic_loot, list(
 		/obj/item/grenade/clusterbuster/emp,
 		/obj/item/grenade/clusterbuster/syndieminibomb,
 		/obj/item/grenade/clusterbuster/spawner_spesscarp,
+//Xenobio crossbreed boxes
+		/obj/item/storage/box/royale/random_slimes,
+		/obj/item/storage/box/royale/random_slimes,
+		/obj/item/storage/box/royale/random_slimes,
 //Various consumables
 		/obj/item/book/granter/action/origami,
 		/obj/item/storage/box/syndie_kit/imp_microbomb,
@@ -271,7 +275,6 @@ GLOBAL_LIST_INIT(battle_royale_insane_loot, list(
 		/obj/item/storage/belt/grenade/full,
 		/obj/item/gun/ballistic/shotgun/bulldog,
 		/obj/item/gun/ballistic/automatic/proto, // NT Saber SMG
-//		/obj/item/gun/ballistic/automatic/c20r,   //Included above as part of a bundle. Kept out of this pool to keep from diluting ammo pools
 		/obj/item/gun/ballistic/sniper_rifle/syndicate,
 		/obj/item/gun/ballistic/automatic/l6_saw,
 		/obj/item/gun/ballistic/automatic/m90, //As-is, with no additional ammo available after unloading to keep from diluting ammo pools

--- a/code/modules/client/loadout/loadout_equipment.dm
+++ b/code/modules/client/loadout/loadout_equipment.dm
@@ -35,6 +35,11 @@
     description = "Comes pre-loaded with 40u of paralytic spider venom"
     path = /obj/item/kitchen/knife/poison/royale
 
+/datum/gear/equipment/toolbox
+    display_name = "strange toolbox"
+    description = "This toolbox looks a bit strange. There is a note inside"
+    path = /obj/item/storage/toolbox/mechanical/old/clean/royale
+
 /datum/gear/equipment/holosword/blue
     display_name = "blue holo sword"
     path = /obj/item/holo/esword/blue
@@ -196,6 +201,11 @@
     display_name = "syndicate playing cards"
     path = /obj/item/toy/cards/deck/syndicate
 
+/datum/gear/equipment/telecrystals
+    display_name = "syndicate telecrystals"
+    description = "Five tiny red crystals without much use. At least unless you can get your hands on an uplink somehow"
+    path = /obj/item/stack/sheet/telecrystal/five
+
 /datum/gear/equipment/glue
     display_name = "bottle of super glue"
     path = /obj/item/syndie_glue/royale
@@ -236,6 +246,144 @@
     new /obj/item/grenade/plastic/x4(src)
     new /obj/item/grenade/plastic/x4(src)
 
+/obj/item/storage/toolbox/ammo/royale
+    name = "ammo box"
+    desc = "Contains a random assortment of ammunition"
+    var/quantity = 14
+
+/obj/item/storage/toolbox/ammo/royale/PopulateContents()
+    var/static/revolversmall = list(
+                /obj/item/ammo_box/c38,
+                /obj/item/ammo_box/c38/match,
+                /obj/item/ammo_box/c38/match/bouncy,
+//              /obj/item/ammo_box/c38/dumdum,   //decided this one was a bit much due to the availability of this weapon, but left it here in case I change my mind later
+                /obj/item/ammo_box/c38/hotshot,
+                /obj/item/ammo_box/c38/iceblox
+    )
+    var/static/stechkin = list(
+                /obj/item/ammo_box/magazine/m10mm,
+                /obj/item/ammo_box/magazine/m10mm/hp,
+                /obj/item/ammo_box/magazine/m10mm/ap,
+                /obj/item/ammo_box/magazine/m10mm/fire
+    )
+    var/static/revolver = list(
+                /obj/item/ammo_box/a357,
+                /obj/item/ammo_box/a357/match
+    )
+    var/static/shotgun = list(
+                /obj/item/storage/box/lethalshot,
+                /obj/item/storage/box/rubbershot,
+                /obj/item/storage/box/incendiary,
+                /obj/item/storage/box/taser,
+                /obj/item/storage/box/ion,
+                /obj/item/storage/box/laser
+    )
+    var/static/rifle = list(
+                /obj/item/ammo_box/a762, //Mosin Nagant
+                /obj/item/ammo_box/magazine/m10mm/rifle // Surplus Rifle
+    )
+    var/static/bulldog = list(
+                /obj/item/ammo_box/magazine/m12g,
+                /obj/item/ammo_box/magazine/m12g/dragon,
+                /obj/item/ammo_box/magazine/m12g/slug,
+                /obj/item/ammo_box/magazine/m12g/stun
+    )
+    var/static/smg = list(
+                /obj/item/ammo_box/magazine/smgm9mm,
+                /obj/item/ammo_box/magazine/smgm9mm/ap,
+                /obj/item/ammo_box/magazine/smgm9mm/fire
+    )
+    var/static/secrifle = list(
+                /obj/item/ammo_box/magazine/wt550m9,
+                /obj/item/ammo_box/magazine/wt550m9/wtap,
+                /obj/item/ammo_box/magazine/wt550m9/wtic,
+                /obj/item/ammo_box/magazine/wt550m9/rubber
+    )
+    var/static/sniper = list(
+                /obj/item/ammo_box/magazine/sniper_rounds,
+                /obj/item/ammo_box/magazine/sniper_rounds/soporific,
+                /obj/item/ammo_box/magazine/sniper_rounds/penetrator,
+                /obj/item/ammo_box/magazine/sniper_rounds/emp,
+                /obj/item/ammo_box/magazine/sniper_rounds/explosive,
+                /obj/item/ammo_box/magazine/sniper_rounds/inferno
+    )
+    var/static/lmg = list(
+                /obj/item/ammo_box/magazine/mm712x82, 
+                /obj/item/ammo_box/magazine/mm712x82/ap,
+                /obj/item/ammo_box/magazine/mm712x82/hollow,
+                /obj/item/ammo_box/magazine/mm712x82/incen,
+                /obj/item/ammo_box/magazine/mm712x82/match
+    )
+    var/rng
+    var/ammunition
+    for(var/i in 1 to quantity)
+        rng = roll(5)
+        switch(rng)
+            if(1)
+                ammunition = pick(revolversmall)
+            if(2)
+                ammunition = pick(stechkin)
+            if(3)
+                ammunition = pick(shotgun)
+            if(4)
+                ammunition = pick(rifle)
+            if(5)
+                rng = roll(6)   //Layer the RNG - common weapon types will comprise most of the ammo
+                switch(rng)
+                    if(1)
+                        ammunition = pick(bulldog)
+                    if(2)
+                        ammunition = pick(smg)
+                    if(3)
+                        ammunition = pick(secrifle)
+                    if(4)
+                        ammunition = pick(sniper)
+                    if(5)
+                        ammunition = pick(lmg)
+                    if(6)
+                        ammunition = pick(revolver)
+        new ammunition(src)
+
+/obj/item/storage/box/incendiary
+    name = "box of incendiary shotgun shells"
+    desc = "A box full of incendiary shotgun shells"
+    icon_state = "breachershot_box"
+    illustration = null
+
+/obj/item/storage/box/incendiary/PopulateContents()
+    for(var/i in 1 to 7)
+        new /obj/item/projectile/bullet/incendiary/shotgun(src)
+
+/obj/item/storage/box/taser
+    name = "box of taser slugs"
+    desc = "A box full of taser slugs"
+    icon_state = "breachershot_box"
+    illustration = null
+
+/obj/item/storage/box/incendiary/PopulateContents()
+    for(var/i in 1 to 7)
+        new /obj/item/ammo_casing/shotgun/stunslug(src)
+
+/obj/item/storage/box/ion
+    name = "box of ionizing shotgun shells"
+    desc = "A box full of ionizing shotgun shells"
+    icon_state = "breachershot_box"
+    illustration = null
+
+/obj/item/storage/box/incendiary/PopulateContents()
+    for(var/i in 1 to 7)
+        new /obj/item/ammo_casing/shotgun/ion(src)
+
+/obj/item/storage/box/laser
+    name = "box of laser shotgun shells"
+    desc = "A box full of laser shotgun shells"
+    icon_state = "breachershot_box"
+    illustration = null
+
+/obj/item/storage/box/incendiary/PopulateContents()
+    for(var/i in 1 to 7)
+        new /obj/item/ammo_casing/shotgun/laserslug(src)
+
 /obj/item/gun/energy/e_gun/mini/heads/royale
     gun_charge = 300
     desc = "It has two settings: Kill and Disable. It isn't very good at either of them, but recharges over time"
@@ -255,9 +403,33 @@
     desc = "A mining tool capable of expelling concentrated plasma bursts. Not very strong, but good at removing limbs"
 
 /obj/item/reagent_containers/spray/flame
+    color = "#ff6600ff"
     volume = 50
-    list_reagents = list(/datum/reagent/clf3 = 50)
-    desc = "A spray bottle, with an unscrewable top. This one came filled with chlorine triflouride"
+    list_reagents = list(/datum/reagent/clf3 = 30)
+    desc = "A spray bottle, with an unscrewable top. This one came filled with liquid fire"
+
+/obj/item/reagent_containers/spray/lube
+    color = "#ee52c7"
+    volume = 100
+    list_reagents = list(/datum/reagent/lube = 50)
+    desc = "A spray bottle, with an unscrewable top. This one came filled with space lube"
+
+/obj/item/reagent_containers/spray/combo
+    color = "#ff0000"
+    volume = 100
+    list_reagents = list(/datum/reagent/lube = 60, /datum/reagent/clf3 = 40)
+    desc = "A spray bottle, with an unscrewable top. This one came filled with flaming space lube"
+
+/obj/item/storage/toolbox/mechanical/old/clean/royale
+    force = 15
+    throwforce = 18
+
+/obj/item/storage/toolbox/mechanical/old/clean/royale/PopulateContents()
+    new /obj/item/paper/royale_toolbox(src)
+
+/obj/item/paper/royale_toolbox
+    name = "Note"
+    info = "If you find any tiny red crystals, keep them in here. The box feeds on them to make you stronger."
 
 /obj/item/kitchen/knife/poison/royale/Initialize(mapload)
     . = ..()
@@ -283,7 +455,7 @@
 
 /obj/item/shield/energy/royale
     max_integrity = 25
-    block_power = 75
+    block_power = 75  //blocking easily destroys the shield instead of player stamina
     desc = "An advanced hard-light shield able to reflect lasers, but not very good at blocking physical attacks. Recharges in ten seconds."
 
 /obj/item/book/granter/martial/karate/royale

--- a/code/modules/client/loadout/loadout_equipment.dm
+++ b/code/modules/client/loadout/loadout_equipment.dm
@@ -908,3 +908,9 @@
 /obj/item/toy/syndicateballoon/glued/Initialize(mapload)
     . = ..()
     ADD_TRAIT(src, TRAIT_NODROP, ROYALE)  //So badass you'll fight with one hand
+
+/obj/structure/closet/crate/necropolis/random/Initialize(mapload)
+    ..()
+    var/obj/structure/closet/crate/necropolis/lavacrate = pick(subtypesof(/obj/structure/closet/crate/necropolis) - /obj/structure/closet/crate/necropolis/tendril/puzzle - /obj/structure/closet/crate/necropolis/tendril)
+    new lavacrate(loc)
+    return INITIALIZE_HINT_QDEL

--- a/code/modules/client/loadout/loadout_equipment.dm
+++ b/code/modules/client/loadout/loadout_equipment.dm
@@ -79,7 +79,7 @@
 
 /datum/gear/equipment/spear/brass
     display_name = "brass spear"
-    path = /obj/item/nullrod/spear/royale
+    path = /obj/item/nullrod/spear/royale //technically slightly stronger than normal spear in a few edge cases
 
 // SHIELDS
 
@@ -214,6 +214,12 @@
 /datum/gear/equipment/fate
     display_name = "fateful bag of dice"
     path = /obj/item/storage/pill_bottle/dicefate
+    cost = 3000
+
+/datum/gear/equipment/floorpills
+    display_name = "bottle of floorpills"
+    description = "You can never really know what you're going to get"
+    path = /obj/item/storage/pill_bottle/floorpill/full
     cost = 3000
 
 /datum/gear/equipment/skub
@@ -483,6 +489,199 @@
         /obj/item/storage/pill_bottle/happy = 1,
         /obj/item/reagent_containers/hypospray/medipen/atropine = 1)
     generate_items_inside(items_inside,src)
+
+/obj/item/storage/box/royale/assorted_syringes
+    name = "box of syringes"
+    desc = "A random assortment of syringes, some of which lost their labels"
+    icon_state = "hugbox"
+    illustration = "syringe"
+
+/obj/item/storage/box/royale/assorted_syringes/PopulateContents()
+    for(var/i in 1 to 14) //twice as many
+        new /obj/item/reagent_containers/syringe/royale/random(src)
+    
+/obj/item/storage/box/royale/unlabeled_syringes
+    name = "box of syringes"
+    desc = "None of these have labels, what am I supposed to do with this?"
+    icon_state = "box"
+    illustration = "syringe"
+
+/obj/item/storage/box/royale/unlabeled_syringes/PopulateContents()
+    for(var/i in 1 to 7)
+        new /obj/item/reagent_containers/syringe/royale/unlabeled(src)
+
+/obj/item/storage/box/royale/med_syringes
+    name = "box of syringes"
+    desc = "All of these are labeled as medicine, but not what kind"
+    icon_state = "alienbox"
+    illustration = "syringe"
+
+/obj/item/storage/box/royale/med_syringes/PopulateContents()
+    for(var/i in 1 to 7)
+        new /obj/item/reagent_containers/syringe/royale/med(src)
+
+/obj/item/storage/box/royale/tox_syringes
+    name = "box of syringes"
+    desc = "Pretty sure all of these could kill me"
+    icon_state = "syndiebox"
+    illustration = "syringe"
+
+/obj/item/storage/box/royale/tox_syringes/PopulateContents()
+    for(var/i in 1 to 7)
+        new /obj/item/reagent_containers/syringe/royale/tox(src)
+
+/obj/item/storage/box/royale/dna_syringes
+    name = "box of injectors"
+    desc = "Seems risky, what if I melt?"
+    icon_state = "secbox"
+    illustration = "dna"
+
+/obj/item/storage/box/royale/dna_syringes/PopulateContents()
+    for(var/i in 1 to 4) //These are pretty strong stuff
+        new /obj/item/dnainjector/random(src)
+
+/obj/item/storage/secure/briefcase/medgun_kit
+    name = "Briefcase of warcrimes"
+    desc = "There's no Geneva in space!"
+
+/obj/item/storage/secure/briefcase/medgun_kit/PopulateContents()
+    var/selection = roll(6) //33% normal syringe gun, 33% advanced syringe gun, 33% DNA gun
+    switch(selection)
+        if(1 to 2) //Normal syringe gun, 14 toxin syringes
+            new /obj/item/gun/syringe(src)
+            new /obj/item/storage/box/royale/tox_syringes(src)
+            new /obj/item/storage/box/royale/tox_syringes(src)
+        if(3) //Rapid syringe gun, 28 random syringes
+            new /obj/item/gun/syringe/rapidsyringe(src)
+            new /obj/item/storage/box/royale/assorted_syringes(src)
+            new /obj/item/storage/box/royale/assorted_syringes(src)
+        if(4) //Dartgun, takes bottles instead of syringes, gets high quality toxins to make up for lack of fire rate
+            new /obj/item/gun/chem(src)
+            new /obj/item/storage/box/syndie_kit/chemical(src)
+        if(5 to 6) //DNA gun, eight injectors
+            new /obj/item/gun/syringe/dna(src)
+            new /obj/item/storage/box/royale/dna_syringes(src)
+            new /obj/item/storage/box/royale/dna_syringes(src)
+
+
+/obj/item/reagent_containers/syringe/royale/random/Initialize(mapload)
+    ..()
+    var/obj/item/reagent_containers/syringe/syringe = pick(\
+        /obj/item/reagent_containers/syringe/random,\
+        /obj/item/reagent_containers/syringe/randmed,\
+        /obj/item/reagent_containers/syringe/randtox,\
+        /obj/item/reagent_containers/syringe/piercing/random,\
+        /obj/item/reagent_containers/syringe/piercing/randmed,\
+        /obj/item/reagent_containers/syringe/piercing/randtox,\
+        /obj/item/reagent_containers/syringe/bluespace/random,\
+        /obj/item/reagent_containers/syringe/bluespace/randmed,\
+        /obj/item/reagent_containers/syringe/bluespace/randtox,\
+        /obj/item/dnainjector/random)
+    new syringe(loc)
+    return INITIALIZE_HINT_QDEL
+
+/obj/item/reagent_containers/syringe/royale/unlabeled/Initialize(mapload)
+    ..()
+    var/obj/item/reagent_containers/syringe/syringe = pick(\
+        /obj/item/reagent_containers/syringe/random,\
+        /obj/item/reagent_containers/syringe/piercing/random,\
+        /obj/item/reagent_containers/syringe/bluespace/random)
+    new syringe(loc)
+    return INITIALIZE_HINT_QDEL
+
+/obj/item/reagent_containers/syringe/royale/med/Initialize(mapload)
+    ..()
+    var/obj/item/reagent_containers/syringe/syringe = pick(\
+        /obj/item/reagent_containers/syringe/randmed,\
+        /obj/item/reagent_containers/syringe/piercing/randmed,\
+        /obj/item/reagent_containers/syringe/bluespace/randmed)
+    new syringe(loc)
+    return INITIALIZE_HINT_QDEL
+
+/obj/item/reagent_containers/syringe/royale/tox/Initialize(mapload)
+    ..()
+    var/obj/item/reagent_containers/syringe/syringe = pick(\
+        /obj/item/reagent_containers/syringe/randtox,\
+        /obj/item/reagent_containers/syringe/piercing/randtox,\
+        /obj/item/reagent_containers/syringe/bluespace/randtox)
+    new syringe(loc)
+    return INITIALIZE_HINT_QDEL
+
+/obj/item/reagent_containers/syringe/random
+    name = "unlabeled syringe"
+    desc = "This syringe has no markings at all, what it contains is anyone's guess"
+
+/obj/item/reagent_containers/syringe/random/Initialize(mapload)
+	list_reagents = list(get_random_reagent_id(CHEMICAL_RNG_FUN) = volume)
+	. = ..()
+
+/obj/item/reagent_containers/syringe/randmed
+    name = "medicinal syringe"
+    desc = "This syringe has a little blue cross on it"
+
+/obj/item/reagent_containers/syringe/randmed/Initialize(mapload)
+	list_reagents = list(pick(subtypesof(/datum/reagent/medicine)) = volume)
+	. = ..()
+
+/obj/item/reagent_containers/syringe/randtox
+    name = "toxic syringe"
+    desc = "This syringe has a little skull and crossbones on it"
+
+/obj/item/reagent_containers/syringe/randtox/Initialize(mapload)
+	list_reagents = list(pick(subtypesof(/datum/reagent/toxin)) = volume)
+	. = ..()
+
+/obj/item/reagent_containers/syringe/piercing/random
+    name = "unlabeled piercing syringe"
+
+/obj/item/reagent_containers/syringe/piercing/random/Initialize(mapload)
+	list_reagents = list(get_random_reagent_id(CHEMICAL_RNG_FUN) = volume)
+	. = ..()
+
+/obj/item/reagent_containers/syringe/piercing/randmed
+    name = "medicinal piercing syringe"
+    desc = "This syringe has a little blue cross on it"
+
+/obj/item/reagent_containers/syringe/piercing/randmed/Initialize(mapload)
+	list_reagents = list(pick(subtypesof(/datum/reagent/medicine)) = volume)
+	. = ..()
+
+/obj/item/reagent_containers/syringe/piercing/randtox
+    name = "toxic piercing syringe"
+    desc = "This syringe has a little skull and crossbones on it"
+
+/obj/item/reagent_containers/syringe/piercing/randtox/Initialize(mapload)
+	list_reagents = list(pick(subtypesof(/datum/reagent/toxin)) = volume)
+	. = ..()
+
+/obj/item/reagent_containers/syringe/bluespace/random
+	name = "unlabeled bluespace syringe"
+
+/obj/item/reagent_containers/syringe/bluespace/random/Initialize(mapload)
+	list_reagents = list(get_random_reagent_id(CHEMICAL_RNG_FUN) = 60)
+	. = ..()
+
+/obj/item/reagent_containers/syringe/bluespace/randmed
+    name = "medicinal bluespace syringe"
+    desc = "This syringe has a little blue cross on it. Be wary of overdosing"
+
+/obj/item/reagent_containers/syringe/bluespace/randmed/Initialize(mapload)
+	list_reagents = list(pick(subtypesof(/datum/reagent/medicine)) = volume)
+	. = ..()
+
+/obj/item/reagent_containers/syringe/bluespace/randtox
+    name = "toxic bluespace syringe"
+    desc = "This syringe has a little skull and crossbones on it. Definitely contains a lethal dose. Probably."
+
+/obj/item/reagent_containers/syringe/bluespace/randtox/Initialize(mapload)
+	list_reagents = list(pick(subtypesof(/datum/reagent/toxin)) = volume)
+	. = ..()
+
+/obj/item/dnainjector/random/Initialize(mapload)
+    ..()
+    var/obj/item/dnainjector/dna = pick(subtypesof(/obj/item/dnainjector) - typesof(/obj/item/dnainjector/anti) - /obj/item/dnainjector/random - /obj/item/dnainjector/activator - /obj/item/dnainjector/telemut/darkbundle)
+    new dna(loc)
+    return INITIALIZE_HINT_QDEL
 
 /obj/item/syndie_glue/royale
     uses = 3

--- a/code/modules/client/loadout/loadout_equipment.dm
+++ b/code/modules/client/loadout/loadout_equipment.dm
@@ -206,6 +206,11 @@
     description = "Five tiny red crystals without much use. At least unless you can get your hands on an uplink somehow"
     path = /obj/item/stack/sheet/telecrystal/five
 
+/datum/gear/equipment/stable_slime
+    display_name = "random stabilized slime extract"
+    path = /obj/item/random_slimecore
+    description = "A random stabilized slime which will provide a passive beneficial effect while it is in your pocket"
+
 /datum/gear/equipment/glue
     display_name = "bottle of super glue"
     path = /obj/item/syndie_glue/royale
@@ -563,6 +568,42 @@
             new /obj/item/storage/box/royale/dna_syringes(src)
             new /obj/item/storage/box/royale/dna_syringes(src)
 
+/obj/item/storage/box/royale/random_slimes
+    name = "box of slimes"
+    desc = "You're not really sure what any of these do"
+    icon_state = "alienbox"
+    illustration = "writing_syndie"
+
+/obj/item/storage/box/royale/random_slimes/PopulateContents()
+    var/slimecore
+    for(var/i in 1 to 7)
+        switch(i)
+            if(1)
+                slimecore = pick(subtypesof(/obj/item/slimecross/burning))
+            if(2)
+                slimecore = pick(subtypesof(/obj/item/slimecross/regenerative))
+            if(3)
+                slimecore = pick(subtypesof(/obj/item/slimecross/stabilized))
+            if(4)
+                slimecore = pick(subtypesof(/obj/item/slimecross/chilling))
+            if(5)
+                slimecore = pick(subtypesof(/obj/item/slimecross/warping))
+            if(6)
+                slimecore = pick(subtypesof(/obj/item/slimecross/gentle))
+            if(7)
+                slimecore = pick(subtypesof(/obj/item/slimecross/crystalline))
+        new slimecore(src)
+    new /obj/item/reagent_containers/syringe/bluespace/plasma(src)
+
+/obj/item/random_slimecore/Initialize(mapload)
+    ..()
+    var/obj/item/slimecross/stabilized/randomcore = pick(subtypesof(/obj/item/slimecross/stabilized) - /obj/item/slimecross/stabilized/rainbow - /obj/item/slimecross/stabilized/grey)
+    new randomcore(loc)
+    return INITIALIZE_HINT_QDEL
+
+/obj/item/reagent_containers/syringe/bluespace/plasma
+    list_reagents = list(/datum/reagent/toxin/plasma = 60)
+    
 
 /obj/item/reagent_containers/syringe/royale/random/Initialize(mapload)
     ..()
@@ -757,7 +798,7 @@
     icon_state = "golhood_yellow"
 
 /obj/item/clothing/suit/hooded/cloak/goliath/royale/invisible
-    alpha = 120
+    alpha = 180
     name = "invisibility cloak"
     desc = "A tattered cloak made of goliath leather. This one makes light and lasers pass right through you but offers no physical protection."
     icon_state = "goliath_cloak_grey"
@@ -914,3 +955,4 @@
     var/obj/structure/closet/crate/necropolis/lavacrate = pick(subtypesof(/obj/structure/closet/crate/necropolis) - /obj/structure/closet/crate/necropolis/tendril/puzzle - /obj/structure/closet/crate/necropolis/tendril)
     new lavacrate(loc)
     return INITIALIZE_HINT_QDEL
+

--- a/code/modules/jobs/job_types/fighter.dm
+++ b/code/modules/jobs/job_types/fighter.dm
@@ -3,7 +3,7 @@
     jobtype = /datum/job/default_royale
 
     id = /obj/item/card/id/silver/royale
-    belt = /obj/item/storage/belt/utility/partial
+    belt = null
     ears = null
     uniform = /obj/item/clothing/under/color/random
     shoes = null
@@ -63,17 +63,15 @@
 	            ACCESS_VAULT, ACCESS_MINING_STATION, ACCESS_XENOBIOLOGY, ACCESS_CE, ACCESS_HOP, ACCESS_HOS, ACCESS_RC_ANNOUNCE,
 	            ACCESS_KEYCARD_AUTH, ACCESS_TCOMSAT, ACCESS_GATEWAY, ACCESS_MINERAL_STOREROOM, ACCESS_MINISAT, ACCESS_NETWORK, ACCESS_CLONING, ACCESS_RD_SERVER)
 
-/obj/item/storage/belt/utility/partial/PopulateContents()
-    new /obj/item/crowbar(src)
-    new /obj/item/geiger_counter(src)
-    new /obj/item/flashlight(src)
-
 /obj/item/storage/box/supplies
     desc = "A box containing the same basic supplies all fighters get"
 
 /obj/item/storage/box/supplies/PopulateContents()
     new /obj/item/reagent_containers/pill/patch/styptic(src)
     new /obj/item/reagent_containers/pill/patch/silver_sulf(src)
+    new /obj/item/crowbar(src)
+    new /obj/item/geiger_counter(src)
+    new /obj/item/flashlight(src)
 
 /obj/item/implant/royale
     name = "tracking implant"

--- a/code/modules/mining/lavaland/necropolis_chests.dm
+++ b/code/modules/mining/lavaland/necropolis_chests.dm
@@ -20,12 +20,10 @@
 
 /obj/structure/closet/crate/necropolis/proc/try_spawn_loot(datum/source, obj/item/item, mob/user, params)
 	SIGNAL_HANDLER
-
-	if(!istype(item, /obj/item/skeleton_key) || spawned_loot)
+	if(spawned_loot)
 		return FALSE
 	spawned_loot = TRUE
-	qdel(item)
-	to_chat(user, "<span class='notice'>You disable the magic lock with the [item].</span>")
+	to_chat(user, "<span class='notice'>You break the magic lock off of the latch.</span>")
 	return TRUE
 
 
@@ -42,38 +40,37 @@
 /obj/structure/closet/crate/necropolis/tendril/try_spawn_loot(datum/source, obj/item/item, mob/user, params) ///proc that handles key checking and generating loot - MAY REPLACE WITH pickweight(loot)
 	var/static/list/necropolis_goodies = list(	//weights to be defined later on, for now they're all the same
 		/obj/item/clothing/glasses/godeye									= 5,
-		/obj/item/pickaxe/diamond											= 5,
-		/obj/item/rod_of_asclepius											= 5,
 		/obj/item/organ/heart/cursed/wizard						 			= 5,
-		/obj/item/ship_in_a_bottle											= 5,
-		/obj/item/jacobs_ladder												= 5,
 		/obj/item/warp_cube/red												= 5,
-		/obj/item/wisp_lantern												= 5,
 		/obj/item/immortality_talisman										= 5,
 		/obj/item/gun/magic/hook											= 5,
-		/obj/item/book_of_babel 											= 5,
 		/obj/item/clothing/neck/necklace/memento_mori						= 5,
 		/obj/item/reagent_containers/glass/waterbottle/relic				= 5,
-		/obj/item/reagent_containers/glass/bottle/necropolis_seed			= 5,
-		/obj/item/borg/upgrade/modkit/lifesteal								= 5,
 		/obj/item/shared_storage/red										= 5,
-		/obj/item/staff/storm												= 5
+		/obj/item/book/granter/spell/fireball								= 5, //fireball requires robes, which take extra work to acquire but are also available via player loadouts. 
+		/obj/item/book/granter/spell/sacredflame							= 5,
+		/obj/item/book/granter/spell/smoke									= 5,
+		/obj/item/book/granter/spell/blind									= 5,
+		/obj/item/book/granter/spell/mindswap								= 5,
+		/obj/item/book/granter/spell/forcewall								= 5,
+		/obj/item/book/granter/spell/barnyard								= 5,
+		/obj/item/book/granter/spell/summonitem								= 5,
 	)
 
 	if(..())
 		var/necropolis_loot = pickweight(necropolis_goodies.Copy())
 		new necropolis_loot(src)
-	return TRUE
 
 /obj/structure/closet/crate/necropolis/can_open(mob/living/user, force = FALSE)
 	if(!spawned_loot)
+		to_chat(user, "<span class='notice'>There is a magic lock holding it shut!\nThe lock appears to be badly damaged, a solid hit with just about anything should break it off.</span>")
 		return FALSE
 	return ..()
 
 /obj/structure/closet/crate/necropolis/examine(mob/user)
 	. = ..()
 	if(!spawned_loot)
-		. += "<span class='notice'>You need a skeleton key to open it.</span>"
+		. += "<span class='notice'>The magic lock appears to be badly damaged, a solid hit with just about anything should break it off.</span>"
 
 //Rod of Asclepius
 /obj/item/rod_of_asclepius
@@ -83,7 +80,7 @@
 	icon_state = "asclepius_dormant"
 	block_upgrade_walk = 1
 	block_level = 1
-	block_power = 40 //blocks very well to encourage using it. Just because you're a pacifist doesn't mean you can't defend yourself
+	block_power = 75 //blocks very well to encourage using it. Just because you're a pacifist doesn't mean you can't defend yourself
 	block_flags = null //not active, so it's null
 	var/activated = FALSE
 	var/usedHand
@@ -910,7 +907,7 @@
 		return
 
 	var/mob/living/carbon/human/H = user
-	var/random = rand(1,3)
+	var/random = rand(1,2)
 
 	switch(random)
 		if(1)
@@ -919,12 +916,11 @@
 			H.eye_color = "fee5a3"
 			H.set_species(/datum/species/lizard)
 		if(2)
-			to_chat(user, "<span class='danger'>Your flesh begins to melt! Miraculously, you seem fine otherwise.</span>")
-			H.set_species(/datum/species/skeleton)
-		if(3)
-			to_chat(user, "<span class='danger'>You feel like you could walk straight through lava now.</span>")
-			H.weather_immunities |= "lava"
-
+			to_chat(user, "<span class='danger'>Power courses through you! You can now shift your form at will.</span>")
+			if(user.mind)
+				var/obj/effect/proc_holder/spell/targeted/shapeshift/dragon/D = new
+				user.mind.AddSpell(D)
+	
 	playsound(user.loc,'sound/items/drink.ogg', rand(10,50), 1)
 	qdel(src)
 
@@ -1024,6 +1020,8 @@
 	if(..())
 		new /obj/item/clothing/suit/space/hostile_environment(src)
 		new /obj/item/clothing/head/helmet/space/hostile_environment(src)
+		new /obj/item/mayhem(src)
+		new /obj/item/blood_contract(src)
 		new /obj/item/crusher_trophy/demon_claws(src)
 
 /obj/item/mayhem

--- a/code/modules/mining/lavaland/necropolis_chests.dm
+++ b/code/modules/mining/lavaland/necropolis_chests.dm
@@ -40,6 +40,7 @@
 /obj/structure/closet/crate/necropolis/tendril/try_spawn_loot(datum/source, obj/item/item, mob/user, params) ///proc that handles key checking and generating loot - MAY REPLACE WITH pickweight(loot)
 	var/static/list/necropolis_goodies = list(	//weights to be defined later on, for now they're all the same
 		/obj/item/clothing/glasses/godeye									= 5,
+		/obj/item/rod_of_asclepius											= 5,
 		/obj/item/organ/heart/cursed/wizard						 			= 5,
 		/obj/item/warp_cube/red												= 5,
 		/obj/item/immortality_talisman										= 5,

--- a/code/modules/projectiles/boxes_magazines/external/sniper.dm
+++ b/code/modules/projectiles/boxes_magazines/external/sniper.dm
@@ -2,7 +2,7 @@
 	name = "sniper rounds (.50)"
 	icon_state = ".50mag"
 	ammo_type = /obj/item/ammo_casing/p50
-	max_ammo = 6
+	max_ammo = 5
 	caliber = ".50"
 
 /obj/item/ammo_box/magazine/sniper_rounds/update_icon()
@@ -20,20 +20,32 @@
 	desc = "Soporific sniper rounds, designed for happy days and dead quiet nights..."
 	icon_state = "soporific"
 	ammo_type = /obj/item/ammo_casing/p50/soporific
-	max_ammo = 3
-	caliber = ".50"
 
 /obj/item/ammo_box/magazine/sniper_rounds/penetrator
 	name = "sniper rounds (penetrator)"
 	desc = "An extremely powerful round capable of passing straight through cover and anyone unfortunate enough to be behind it."
 	ammo_type = /obj/item/ammo_casing/p50/penetrator
-	max_ammo = 5
+
+/obj/item/ammo_box/magazine/sniper_rounds/emp
+	name = "sniper rounds (EMP)"
+	desc = ".50 caliber rounds containing an iron-uranium core which will cause an electromagnetic pulse on impact."
+	ammo_type = /obj/item/ammo_casing/p50/emp
+
+/obj/item/ammo_box/magazine/sniper_rounds/explosive
+	name = "sniper rounds (penetrator)"
+	desc = ".50 caliber rounds with a small explosive package."
+	ammo_type = /obj/item/ammo_casing/p50/explosive
+
+/obj/item/ammo_box/magazine/sniper_rounds/inferno
+	name = "sniper rounds (penetrator)"
+	desc = ".50 caliber rounds containing a highly volatile core which will burst into flames on impact."
+	ammo_type = /obj/item/ammo_casing/p50/inferno
 
 /obj/item/ammo_box/sniper
 	name = "ammo box (.50)"
 	icon_state = "50cal"
 	ammo_type = /obj/item/ammo_casing/p50
-	max_ammo = 6
+	max_ammo = 5
 	materials = list(/datum/material/iron = 50000)
 
 /obj/item/ammo_box/sniper/soporific

--- a/code/modules/projectiles/guns/ballistic/automatic.dm
+++ b/code/modules/projectiles/guns/ballistic/automatic.dm
@@ -15,7 +15,6 @@
 	desc = "A prototype three-round burst 9mm submachine gun, designated 'SABR'. Has a threaded barrel for suppressors."
 	icon_state = "saber"
 	mag_type = /obj/item/ammo_box/magazine/smgm9mm
-	pin = null
 	fire_rate = 5
 	fire_delay = 2
 	bolt_type = BOLT_TYPE_LOCKING

--- a/code/modules/projectiles/guns/ballistic/automatic.dm
+++ b/code/modules/projectiles/guns/ballistic/automatic.dm
@@ -84,8 +84,8 @@
 	update_icon()
 
 /obj/item/gun/ballistic/automatic/wt550
-	name = "security auto rifle"
-	desc = "An outdated personal defence weapon. Uses 4.6x30mm rounds and is designated the WT-550 Automatic Rifle."
+	name = "WT-550 Automatic Rifle"
+	desc = "An outdated personal defence weapon. Uses 4.6x30mm rounds"
 	icon_state = "wt550"
 	item_state = "arg"
 	mag_type = /obj/item/ammo_box/magazine/wt550m9

--- a/code/modules/projectiles/guns/energy.dm
+++ b/code/modules/projectiles/guns/energy.dm
@@ -74,7 +74,7 @@
 	var/frequency_to_use = 0
 
 	if(shot.e_cost > 0)
-		shot_cost_percent = FLOOR(clamp(shot.e_cost / cell.maxcharge, 0, 1) * 100, 1)
+		shot_cost_percent = FLOOR(clamp(shot.e_cost / cell.maxcharge, 0.01, 1) * 100, 1)
 		max_shots = round(100/shot_cost_percent)
 		shots_left = round(batt_percent/shot_cost_percent)
 		frequency_to_use = sin((90/max_shots) * shots_left)

--- a/code/modules/projectiles/guns/energy/energy_gun.dm
+++ b/code/modules/projectiles/guns/energy/energy_gun.dm
@@ -118,7 +118,6 @@
 	icon_state = "nucgun"
 	item_state = "nucgun"
 	charge_delay = 10
-	pin = null
 	can_charge = FALSE
 	ammo_x_offset = 1
 	ammo_type = list(/obj/item/ammo_casing/energy/laser, /obj/item/ammo_casing/energy/disabler)

--- a/code/modules/projectiles/guns/energy/laser.dm
+++ b/code/modules/projectiles/guns/energy/laser.dm
@@ -86,7 +86,6 @@
 	flags_1 =  CONDUCT_1
 	slot_flags = ITEM_SLOT_BACK
 	ammo_type = list(/obj/item/ammo_casing/energy/laser/accelerator)
-	pin = null
 	ammo_x_offset = 3
 
 /obj/item/ammo_casing/energy/laser/accelerator
@@ -111,7 +110,6 @@
 	icon_state = "xray"
 	item_state = null
 	ammo_type = list(/obj/item/ammo_casing/energy/xray)
-	pin = null
 	ammo_x_offset = 3
 	w_class = WEIGHT_CLASS_BULKY
 

--- a/code/modules/projectiles/guns/energy/laser_gatling.dm
+++ b/code/modules/projectiles/guns/energy/laser_gatling.dm
@@ -13,24 +13,16 @@
 	w_class = WEIGHT_CLASS_HUGE
 	var/obj/item/gun/energy/minigun/gun
 	var/armed = 0 //whether the gun is attached, 0 is attached, 1 is the gun is wielded.
-	var/overheat = 0
-	var/overheat_max = 40
-	var/heat_diffusion = 0.5
 
 /obj/item/minigunpack/Initialize(mapload)
 	. = ..()
 	gun = new(src)
-	START_PROCESSING(SSobj, src)
 
 /obj/item/minigunpack/Destroy()
 	if(!QDELETED(gun))
 		qdel(gun)
 	gun = null
-	STOP_PROCESSING(SSobj, src)
 	return ..()
-
-/obj/item/minigunpack/process(delta_time)
-	overheat = max(0, overheat - heat_diffusion * delta_time)
 
 //ATTACK HAND IGNORING PARENT RETURN VALUE
 /obj/item/minigunpack/attack_hand(var/mob/living/carbon/user)
@@ -95,11 +87,6 @@
 	update_icon()
 	user.update_inv_back()
 
-/obj/item/minigunpack/on_emag(mob/user)
-	..()
-	to_chat(user, "<span class='warning'>You break the heat sensor.</span>")
-	overheat_max = 1000
-
 /obj/item/stock_parts/cell/minigun
 	name = "Minigun gun fusion core"
 	maxcharge = 500000
@@ -125,7 +112,11 @@
 	fire_sound = 'sound/weapons/laser.ogg'
 	item_flags = NEEDS_PERMIT | SLOWS_WHILE_IN_HAND
 	full_auto = TRUE
-	var/cooldown = 0
+	var/cooldown
+	var/last_fired
+	var/spin = 0
+	var/current_heat = 0
+	var/overheat = 80 //8 second cooldown
 	var/obj/item/minigunpack/ammo_pack
 
 /obj/item/gun/energy/minigun/Initialize(mapload)
@@ -154,38 +145,51 @@
 
 /obj/item/gun/energy/minigun/process_fire(atom/target, mob/living/user, message = TRUE, params = null, zone_override = "", bonus_spread = 0)
 	if(ammo_pack)
-		if(obj_flags & EMAGGED)
-			if(cooldown < world.time)
-				cooldown = world.time + 50
-				playsound(get_turf(src), 'sound/weapons/heavyminigunstart.ogg', 50, 0, 0)
-				slowdown = 5
-				sleep(15)
-				if(ammo_pack.overheat < ammo_pack.overheat_max)
-					ammo_pack.overheat += burst_size
-					playsound(get_turf(src), 'sound/weapons/heavyminigunshoot.ogg', 60, 0, 0)
-					..()
-					playsound(get_turf(src), 'sound/weapons/heavyminigunstop.ogg', 50, 0, 0)
-					slowdown = initial(slowdown)
-				else
-					to_chat(user, "The gun's heat sensor locked the trigger to prevent lens damage.")
+		if(cooldown < world.time)
+			if(current_heat >= overheat) //We've been firing too long, shut it down
+				to_chat(user, "<span class='warning'>[src]'s heat sensor locked the trigger to prevent lens damage.</span>")
+				shoot_with_empty_chamber(user)
+				stop_firing()
+			if(spin >= 12) //full rate of fire
+				fire_effect(TRUE)
+				..()
+			else if(spin >= 6 && spin % 2) //Starting to fire rounds
+				fire_effect(TRUE)
+				..()
+			else if(spin < 6 && spin % 2) //Just starting to spin, no rounds fired
+				fire_effect()
+			else if(spin >= 6) //Full spin sound between shots
+				fire_effect()
+			spin++
+			last_fired = world.time
 		else
-			..()
+			to_chat(user, "<span class='warning'>[src] is not ready to fire again yet!</span>")
+	else
+		to_chat(user, "<span class='warning'>There is no power supply for [src]</span>")
+		return //don't process firing the gun if it's on cooldown or doesn't have an ammo pack somehow. 
+
+/obj/item/gun/energy/minigun/proc/stop_firing()
+	if(current_heat) //Don't play the sound or apply cooldown unless it has actually fired at least once
+		playsound(get_turf(src), 'sound/weapons/heavyminigunstop.ogg', 50, 0, 0)
+		cooldown = world.time + max(current_heat, 2 SECONDS) //2 to 8 seconds depending on how hot it was. At least 1.5 seconds is required to prevent overlapping conflicts with spinups and spindowns.
+		current_heat = 0
+	spin = 0
+
+/obj/item/gun/energy/minigun/proc/check_firing()
+	if(last_fired + 4 <= world.time)
+		stop_firing()
+
+/obj/item/gun/energy/minigun/proc/fire_effect(heating)
+	playsound(get_turf(src), 'sound/weapons/heavyminigunstart.ogg', 40, 0, 0)
+	addtimer(CALLBACK(src, .proc/check_firing,), 5)
+	if(heating)
+		current_heat += 2
 
 /obj/item/gun/energy/minigun/afterattack(atom/target, mob/living/user, flag, params)
 	if(!ammo_pack || ammo_pack.loc != user)
-		to_chat(user, "You need the backpack power source to fire the gun!")
+		to_chat(user, "<span class='warning'>You need the backpack power source to fire the gun!</span>")
 	. = ..()
 
 /obj/item/gun/energy/minigun/dropped(mob/living/user)
 	..()
 	ammo_pack.attach_gun(user)
-
-/obj/item/gun/energy/minigun/on_emag(mob/user)
-	..()
-	fire_sound = null
-	spread = 60
-	recoil = 1
-	burst_size = 120
-	fire_delay = 0.2
-	playsound(get_turf(src), 'sound/magic/clockwork/invoke_general.ogg', 30, 0, 0)
-	to_chat(user, "<span class='colossus'>OVERDRIVE.</span>")

--- a/code/modules/projectiles/guns/energy/special.dm
+++ b/code/modules/projectiles/guns/energy/special.dm
@@ -19,7 +19,6 @@
 	worn_icon_state = "ioncarbine"
 	w_class = WEIGHT_CLASS_NORMAL
 	slot_flags = ITEM_SLOT_BELT
-	pin = null
 	ammo_x_offset = 2
 	flight_x_offset = 18
 	flight_y_offset = 11
@@ -32,7 +31,6 @@
 	desc = "A gun that discharges high amounts of controlled radiation to slowly break a target into component elements."
 	icon_state = "decloner"
 	ammo_type = list(/obj/item/ammo_casing/energy/declone)
-	pin = null
 	ammo_x_offset = 1
 
 /obj/item/gun/energy/decloner/update_icon()
@@ -116,7 +114,6 @@
 	materials = list(/datum/material/iron=4000)
 	suppressed = null
 	ammo_type = list(/obj/item/ammo_casing/energy/bolt/large)
-	pin = null
 
 /obj/item/gun/energy/kinetic_accelerator/crossbow/radbow
 	name = "gamma bow"
@@ -340,7 +337,6 @@
 	cell_type = "/obj/item/stock_parts/cell/high"
 	automatic = 1
 	fire_rate = 4
-	pin = null
 
 /obj/item/gun/energy/temperature/pin
 	pin = /obj/item/firing_pin

--- a/code/modules/projectiles/guns/energy/stun.dm
+++ b/code/modules/projectiles/guns/energy/stun.dm
@@ -13,7 +13,6 @@
 	item_state = "tesla"
 	ammo_type = list(/obj/item/ammo_casing/energy/tesla_revolver)
 	can_flashlight = FALSE
-	pin = null
 	shaded_charge = 1
 	fire_rate = 1.5
 

--- a/code/modules/projectiles/guns/misc/beam_rifle.dm
+++ b/code/modules/projectiles/guns/misc/beam_rifle.dm
@@ -30,7 +30,6 @@
 	ammo_type = list(/obj/item/ammo_casing/energy/beam_rifle/hitscan)
 	cell_type = /obj/item/stock_parts/cell/beam_rifle
 	canMouseDown = TRUE
-	pin = null
 	var/aiming = FALSE
 	var/aiming_time = 12
 	var/aiming_time_fire_threshold = 5


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Adds a lot more stuff to supply crates:
* Spray bottles with lube, clf3, and both at the same time
* TC toolbox
* Assorted shields
* Most types of ammo in the form of a bulky ammobox that contains an assortment. 
* Reagent warfare items
  * Boxes containing several flavors of random syringes with ambiguous labels or no label at all!
  * Syndicate box of toxins (with no means of application included)
  * A "warcrime kit" that contains some kind of syringe gun and few matching syringes
  * Snail transformation injector for use on others
  * Gorilla transformation injector for use on self
* Various first aid supplies and autosurgeons
* All manner of grenades including clusterbang variants
* Sharpeners
* Gorilla cubes
* A syndicate balloon with glue on it (also available via loadout if you want to show off)
* A couple more outdated rifles to keep the mosin nagant company
* Nanotrasen Saber SMG
* Clockwork bow that regenerates its arrows
* All manner of special energy weapons that never really got to see the light of day
  * Including a newly polished laser gatling gun
* Necropolis chests that don't need keys to unlock
  * Normal chests have had several spellbooks added to their loot pool and had most useless items removed from it (Asclepius is still there with greatly improved block stats. You won't be able to do much killing with it, but you can certainly do a moderate amount of trolling)
  * Boss chests will include previously removed loot, including bottle of mayhem, blood contract, and dragon transformation

Additionally:
* Geiger counter starts on
* Repaths dnainjectors meant to remove mutations (so they could be easily filtered out of random injector pool)
* Removes the toolbelt from initial loadout, instead shuffling those items into the box players start with
* Adds firing pins to all the guns that spawned without one by default

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

More loot good. 

## Changelog
:cl:
add: Lots more supply crate loot
tweak: no more toolbelt on spawn, but all the items within it are now stored in your box
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
