### PR TITLE
overrides player start location

### DIFF
--- a/code/modules/mob/dead/new_player/new_player.dm
+++ b/code/modules/mob/dead/new_player/new_player.dm
@@ -20,11 +20,14 @@
 		var/atom/movable/screen/splash/S = new(null, client, TRUE, TRUE)
 		S.Fade(TRUE)
 
+	var/titlescreen = locate(9, 174, 1)
+	forceMove(titlescreen)
+/*
 	if(length(GLOB.newplayer_start))
 		forceMove(pick(GLOB.newplayer_start))
 	else
 		forceMove(locate(1,1,1))
-
+*/
 	ComponentInitialize()
 
 	. = ..()


### PR DESCRIPTION
## About the pull request

Hardcodes the initial player start location. 
Title subsystem still overrides it, provided it works correctly. 