### PR TITLE
Various requests + one fix

### DIFF
--- a/code/game/gamemodes/battleroyale/royale.dm
+++ b/code/game/gamemodes/battleroyale/royale.dm
@@ -25,7 +25,7 @@
     var/list/active_players = list()
 
     for(var/mob/player in player_list) //checking for all mobs instead of just humans
-        if((!player.client) || (is_centcom_level(player.z)))
+        if((!player.client) || (is_centcom_level(player.z) || (isrevenant(player))))
             continue
         var/turf/T = get_turf(player)
         if(T.x > 128 + GLOB.battle_royale.radius || T.x < 128 - GLOB.battle_royale.radius || T.y > 128 + GLOB.battle_royale.radius || T.y < 128 - GLOB.battle_royale.radius)

--- a/code/modules/admin/battle_royale.dm
+++ b/code/modules/admin/battle_royale.dm
@@ -420,11 +420,13 @@ GLOBAL_DATUM(battle_royale, /datum/battle_royale_controller)
 */
 	//Once every 15 seconsd
 	// 1,920 seconds (about 32 minutes per game)
-	if(process_num % 15)
+	if(process_num % 15 == 0)
+		var/player_list = get_sentient_mobs()
+		field_delay = (clamp(length(player_list), 5, 20) * 1 + (red_alert + delta_alert + delta_alert + delta_alert)) //half wallspeed at red, 20% wallspeed at delta. Scales with players
+		generate_basic_loot(1)
 		if(SSticker.mode)
 			SSticker.mode.check_win()
 	if(process_num % (field_delay) == 0)
-		generate_basic_loot(1)
 		for(var/obj/effect/death_wall/wall as() in death_wall)
 			wall.decrease_size()
 			if(QDELETED(wall))

--- a/code/modules/atmospherics/machinery/components/unary_devices/vent_pump.dm
+++ b/code/modules/atmospherics/machinery/components/unary_devices/vent_pump.dm
@@ -360,6 +360,7 @@
 	icon_state = "vent_map_siphon_on-3"
 
 /obj/machinery/atmospherics/components/unary/vent_pump/siphon/atmos/toxin_output
+	internal_pressure_bound = 0 //no easy mass plasma flood
 	name = "plasma tank output inlet"
 	id_tag = ATMOS_GAS_MONITOR_OUTPUT_TOX
 /obj/machinery/atmospherics/components/unary/vent_pump/siphon/atmos/oxygen_output
@@ -382,7 +383,6 @@
 	id_tag = ATMOS_GAS_MONITOR_OUTPUT_INCINERATOR
 	frequency = FREQ_ATMOS_CONTROL
 /obj/machinery/atmospherics/components/unary/vent_pump/siphon/atmos/toxins_mixing_output
-	internal_pressure_bound = 0 //no easy mass plasma
 	name = "toxins mixing output inlet"
 	id_tag = ATMOS_GAS_MONITOR_OUTPUT_TOXINS_LAB
 	frequency = FREQ_ATMOS_CONTROL

--- a/code/modules/events/portal_storm.dm
+++ b/code/modules/events/portal_storm.dm
@@ -2,6 +2,7 @@
 	name = "Portal Storm: Syndicate Shocktroops"
 	typepath = /datum/round_event/portal_storm/syndicate_shocktroop
 	weight = 5
+	max_occurrences = 0
 	min_players = 15
 	earliest_start = 30 MINUTES
 


### PR DESCRIPTION
## About The Pull Request

* Wall speed now scales with players and alert level
* Disables syndicate shocktroopers - too strong for combatants
* Revenants can no longer win and do not count as living players
* Fixes easy mass plasma flooding (I applied the 0 to the wrong object originally)