### PR TITLE
Fixes syndicate spawners + admin loot spawns

### DIFF
--- a/code/modules/admin/battle_royale.dm
+++ b/code/modules/admin/battle_royale.dm
@@ -578,6 +578,8 @@ GLOBAL_DATUM(battle_royale, /datum/battle_royale_controller)
 		good_drops += pick(GLOB.battle_royale_good_loot)
 	if(!silent)
 		send_item(good_drops, announce = "Incoming extended supply materials.", force_time = 30 SECONDS)
+	else
+		send_item(good_drops, force_time = 30 SECONDS)
 
 /datum/battle_royale_controller/proc/admin_good_drop(amount=1)
 	priority_announce("Incoming extended supply materials: \n[amount] crates in various locations\n ETA: 30 Seconds.", "High Command Supply Control", SSstation.announcer.get_rand_alert_sound())
@@ -591,6 +593,8 @@ GLOBAL_DATUM(battle_royale, /datum/battle_royale_controller)
 		item = pick(GLOB.battle_royale_insane_loot) //Reroll once if either "jackpot" item rolls. Makes both of them exceedingly rare
 	if(!silent)
 		send_item(item, announce = "We found a weird looking package in the back of our warehouse. We have no idea what is in it, but it is marked as incredibily dangerous and could be a superweapon.", force_time = 60 SECONDS)
+	else
+		send_item(item, force_time = 60 SECONDS)
 
 /datum/battle_royale_controller/proc/admin_endgame_drop(amount=1)
 	priority_announce("Incoming (REDACTED) grade supplies\n[amount] crates in various locations\n ETA: 60 Seconds.", "High Command Supply Control", SSstation.announcer.get_rand_alert_sound())

--- a/code/modules/antagonists/_common/antag_spawner.dm
+++ b/code/modules/antagonists/_common/antag_spawner.dm
@@ -116,8 +116,8 @@
 
 
 /obj/item/antag_spawner/nuke_ops/attack_self(mob/user)
-	if(!(check_usability(user)))
-		return
+	//if(!(check_usability(user)))
+	//	return
 
 	to_chat(user, "<span class='notice'>You activate [src] and wait for confirmation.</span>")
 	var/list/nuke_candidates = pollGhostCandidates("Do you want to play as a syndicate [borg_to_spawn ? "[lowertext(borg_to_spawn)] cyborg":"operative"]?", ROLE_OPERATIVE, null, ROLE_OPERATIVE, 150, POLL_IGNORE_SYNDICATE)


### PR DESCRIPTION
## About The Pull Request

* Nuclear and clown operative spawners no longer require the user to be operatives themselves
* Admin procs for spawning additional loot drops now work correctly