### PR TITLE
Bugs of the day

### DIFF
--- a/code/datums/weather/weather_types/radiation_storm.dm
+++ b/code/datums/weather/weather_types/radiation_storm.dm
@@ -8,8 +8,8 @@
 
 	weather_message = "<span class='userdanger'><i>You feel waves of heat wash over you! Find shelter!</i></span>"
 	weather_overlay = "ash_storm"
-	weather_duration_lower = 600
-	weather_duration_upper = 1500
+	weather_duration_lower = 300
+	weather_duration_upper = 450
 	weather_color = "green"
 	weather_sound = 'sound/misc/bloblarm.ogg'
 

--- a/code/game/gamemodes/battleroyale/royale.dm
+++ b/code/game/gamemodes/battleroyale/royale.dm
@@ -25,7 +25,7 @@
     var/list/active_players = list()
 
     for(var/mob/living/player in player_list) //checking for all living mobs instead of just humans
-        if((!player.client) || (is_centcom_level(player.z) || isrevenant(player) || istype(player, /mob/living/carbon/human/species/shadow/nightmare) || player.ventcrawler))
+        if((!player.client) || (is_centcom_level(player.z) || (is_reserved_level(player.z)) || isrevenant(player) || istype(player, /mob/living/carbon/human/species/shadow/nightmare) || player.ventcrawler))
             continue
         var/turf/T = get_turf(player)
         if(T.x > 128 + GLOB.battle_royale.radius || T.x < 128 - GLOB.battle_royale.radius || T.y > 128 + GLOB.battle_royale.radius || T.y < 128 - GLOB.battle_royale.radius)

--- a/code/modules/jobs/job_types/exploration_team.dm
+++ b/code/modules/jobs/job_types/exploration_team.dm
@@ -25,8 +25,8 @@
 	species_outfits = list(
 		SPECIES_PLASMAMAN = /datum/outfit/plasmaman/exploration_crew
 	)
-	biohazard = 40//who knows what you'll find out there that could have nasties on it...
 
+/*
 /datum/job/exploration_crew/equip(mob/living/carbon/human/H, visualsOnly, announce, latejoin, datum/outfit/outfit_override, client/preference_source)
 	if(outfit_override)
 		return ..()
@@ -123,7 +123,7 @@
 	backpack = /obj/item/storage/backpack/medic
 	satchel = /obj/item/storage/backpack/satchel/med
 	duffelbag = /obj/item/storage/backpack/duffelbag/med
-
+*/
 /datum/outfit/job/exploration_crew/hardsuit
 	name = "Exploration Crew (Hardsuit)"
 	suit = /obj/item/clothing/suit/space/hardsuit/exploration

--- a/code/modules/mob/living/silicon/pai/pai.dm
+++ b/code/modules/mob/living/silicon/pai/pai.dm
@@ -26,6 +26,7 @@
 	light_power = 1
 	light_range = 5
 	light_on = FALSE
+	ventcrawler = VENTCRAWLER_ALWAYS
 
 	/// Used as currency to purchase different abilities
 	var/ram = 100


### PR DESCRIPTION
## About The Pull Request

Closes #51 
Closes #53
Closes #54

* Reduces the duration of radstorms to a maximum of 45 seconds (down from a maximum of 150)
* Unlucky players should no longer gib in transit - please report if this continues
* Exploration crew should now spawn with fighter gear
* pAI no longer count as combatants