### PR TITLE
Adds the conniver's switchblade

### DIFF
--- a/code/game/objects/items/weaponry.dm
+++ b/code/game/objects/items/weaponry.dm
@@ -419,7 +419,7 @@ for further reading, please see: https://github.com/tgstation/tgstation/pull/301
 	extended_icon_state = "switchblade_ext_msf"
 
 /obj/item/switchblade/plastitanium/spy
-	name = "conniver's knife"
+	name = "conniver's switchblade"
 	desc = "Gentlemen, this game is as good as mine!"
 	var/backstab_dir
 

--- a/code/game/objects/items/weaponry.dm
+++ b/code/game/objects/items/weaponry.dm
@@ -418,6 +418,22 @@ for further reading, please see: https://github.com/tgstation/tgstation/pull/301
 	extended_throwforce = 17
 	extended_icon_state = "switchblade_ext_msf"
 
+/obj/item/switchblade/plastitanium/spy
+	name = "conniver's knife"
+	desc = "Gentlemen, this game is as good as mine!"
+	var/backstab_dir
+
+/obj/item/switchblade/plastitanium/spy/afterattack(atom/target, mob/user, proximity_flag, click_parameters)
+	. = ..()
+	if(extended && iscarbon(target) && iscarbon(user))
+		var/mob/living/carbon/C_target = target
+		var/mob/living/carbon/C_user = user
+		if(C_user.zone_selected == BODY_ZONE_CHEST)
+			backstab_dir = get_dir(C_user, C_target)
+			if((C_user.dir & backstab_dir) && (C_target.dir & backstab_dir))
+				C_target.apply_damage(20, BRUTE, def_zone = BODY_ZONE_CHEST) //ignores armor
+				playsound(src, 'sound/weapons/parry.ogg', 75, 1)
+
 /obj/item/phone
 	name = "red phone"
 	desc = "Should anything ever go wrong..."

--- a/code/modules/admin/battle_royale.dm
+++ b/code/modules/admin/battle_royale.dm
@@ -15,6 +15,7 @@ GLOBAL_LIST_INIT(battle_royale_basic_loot, list(
 		/obj/item/gun/energy/kinetic_accelerator/crossbow/royale,
 		/obj/item/gun/energy/disabler,
 		/obj/item/gun/energy/plasmacutter/adv/royale,
+		/obj/item/switchblade/plastitanium/spy,
 		/obj/item/kitchen/knife/poison/royale,
 		/obj/item/kitchen/knife/combat,
 		/obj/item/switchblade,

--- a/code/modules/client/loadout/loadout_equipment.dm
+++ b/code/modules/client/loadout/loadout_equipment.dm
@@ -40,6 +40,11 @@
     description = "Comes pre-loaded with 40u of paralytic spider venom"
     path = /obj/item/kitchen/knife/poison/royale
 
+/datum/gear/equipment/knife/spy
+    display_name = "conniver's knife"
+    description = "deals extra, armor-piercing damage if you attack from behind"
+    path = /obj/item/switchblade/plastitanium/spy
+
 /datum/gear/equipment/toolbox
     display_name = "strange toolbox"
     description = "This toolbox looks a bit strange. There is a note inside"

--- a/code/modules/client/loadout/loadout_equipment.dm
+++ b/code/modules/client/loadout/loadout_equipment.dm
@@ -41,7 +41,7 @@
     path = /obj/item/kitchen/knife/poison/royale
 
 /datum/gear/equipment/knife/spy
-    display_name = "conniver's knife"
+    display_name = "conniver's switchblade"
     description = "deals extra, armor-piercing damage if you attack from behind"
     path = /obj/item/switchblade/plastitanium/spy
 


### PR DESCRIPTION
## About The Pull Request

* A new item, the "conniver's switchblade" is now available for loadout and low-tier crates
* Same base stats as plastitanium switchblade, 15 force and 17 throwforce
* If targetting chest and attacking from behind, does a bonus 20 damage that ignores armor for a total of 35 damage