### PR TITLE
Transit lane is whitelisted for battle royale death zone

### DIFF
--- a/code/game/gamemodes/battleroyale/royale.dm
+++ b/code/game/gamemodes/battleroyale/royale.dm
@@ -28,6 +28,8 @@
         if((!player.client) || (is_centcom_level(player.z) || (is_reserved_level(player.z)) || isrevenant(player) || istype(player, /mob/living/carbon/human/species/shadow/nightmare) || player.ventcrawler))
             continue
         var/turf/T = get_turf(player)
+        if(istype(T, /area/centcom/supplypod/supplypod_temp_holding))
+            continue
         if(T.x > 128 + GLOB.battle_royale.radius || T.x < 128 - GLOB.battle_royale.radius || T.y > 128 + GLOB.battle_royale.radius || T.y < 128 - GLOB.battle_royale.radius)
             to_chat(player, "<span class='warning'>You have left the zone!</span>")
             player.gib()


### PR DESCRIPTION
## About The Pull Request

* Even though the transit lane is part of a Z-level that is already whitelisted, players are still getting gibbed there. This whitelists the area on top of the z-level. 