### PR TITLE
Explosions and fire

### DIFF
--- a/code/__DEFINES/radio.dm
+++ b/code/__DEFINES/radio.dm
@@ -92,9 +92,9 @@
 #define FREQ_SIGNALER 1457  //! the default for new signalers
 #define FREQ_COMMON 1459  //! Common comms frequency, dark green
 
-#define MAX_FREQ 1489 // ------------------------------------------------------
+#define MAX_FREQ 1457 // ------------------------------------------------------
 
-#define MAX_FREE_FREQ 1599 // -------------------------------------------------
+#define MAX_FREE_FREQ 1457 // -------------------------------------------------
 
 // Transmission types.
 #define TRANSMISSION_WIRE 0  //! some sort of wired connection, not used
@@ -111,7 +111,7 @@
 #define RADIO_MAGNETS "magnets"
 #define RADIO_XENOA "xenoa_radio"
 
-#define DEFAULT_SIGNALER_CODE 30
+#define DEFAULT_SIGNALER_CODE 15
 
 //Requests Console
 #define REQ_NO_NEW_MESSAGE 				0

--- a/code/_globalvars/lists/objects.dm
+++ b/code/_globalvars/lists/objects.dm
@@ -4,6 +4,7 @@ GLOBAL_LIST_EMPTY(airlocks)					        //list of all airlocks
 GLOBAL_LIST_EMPTY(mechas_list)				        //list of all mechs. Used by hostile mobs target tracking.
 GLOBAL_LIST_EMPTY(shuttle_caller_list)  		    //list of all communication consoles and AIs, for automatic shuttle calls when there are none.
 GLOBAL_LIST_EMPTY(machines)					        //NOTE: this is a list of ALL machines now. The processing machines list is SSmachine.processing !
+GLOBAL_LIST_EMPTY(grenades)							//A list of all grenade objects in the game
 GLOBAL_LIST_EMPTY(navigation_computers)				//list of all /obj/machinery/computer/shuttle_flight
 GLOBAL_LIST_EMPTY(syndicate_shuttle_boards)	        //important to keep track of for managing nukeops war declarations.
 GLOBAL_LIST_EMPTY(navbeacons)					    //list of all bot nagivation beacons, used for patrolling.

--- a/code/game/gamemodes/battleroyale/royale.dm
+++ b/code/game/gamemodes/battleroyale/royale.dm
@@ -130,6 +130,33 @@
     new randnade(loc)
     return INITIALIZE_HINT_QDEL
 
+/obj/item/red_button
+	name = "big red button"
+	desc = "How could you not push the button?"
+	icon = 'icons/obj/assemblies.dmi'
+	icon_state = "bigred"
+	item_state = "electronic"
+	lefthand_file = 'icons/mob/inhands/misc/devices_lefthand.dmi'
+	righthand_file = 'icons/mob/inhands/misc/devices_righthand.dmi'
+	w_class = WEIGHT_CLASS_TINY
+	var/used
+
+/obj/item/red_button/attack_self(mob/user)
+    if(!used)
+        if(length(GLOB.grenades))
+            playsound(src, 'sound/machines/triple_beep.ogg', 20, TRUE)
+            trigger(user)
+            used = TRUE
+    else
+        to_chat(user, "<span class='warning'>It doesn't seem to do anything anymore...</span>")
+    playsound(src, 'sound/machines/click.ogg', 20, 1)
+
+/obj/item/red_button/proc/trigger(mob/user)
+    for(var/obj/item/grenade/G in GLOB.grenades)
+        playsound(G, 'sound/weapons/armbomb.ogg', 100, 1)
+        G.audible_message("[G] begins beeping ominously")
+        addtimer(CALLBACK(G, /obj/item/grenade/proc/prime), rand(5 SECONDS, 20 SECONDS))
+
 /obj/item/storage/toolbox/ammo/royale
     name = "ammo box"
     desc = "Contains a random assortment of ammunition"

--- a/code/game/gamemodes/battleroyale/royale.dm
+++ b/code/game/gamemodes/battleroyale/royale.dm
@@ -94,10 +94,41 @@
     new /obj/item/wrench(src)
 
 /obj/item/storage/box/loadout/explosives/PopulateContents()
+    var/scaling = length(GLOB.player_list)
+    var/count = 1
     new /obj/item/grenade/plastic/c4/x4(src)
-    new /obj/item/grenade/plastic/c4/x4(src)
-    new /obj/item/grenade/plastic/c4/x4(src)
-    new /obj/item/grenade/plastic/c4/x4(src)
+    while(scaling >= 8 && count < 5)
+        new /obj/item/grenade/plastic/c4/x4(src)
+        scaling -= 8
+        count++
+
+/obj/item/storage/box/loadout/grenades/PopulateContents()
+    var/scaling = length(GLOB.player_list)
+    var/count = 2
+    new /obj/item/grenade/random(src)
+    new /obj/item/grenade/random(src)
+    while(scaling >= 4 && count < 8)
+        new /obj/item/grenade/random(src)
+        scaling -= 4
+        count++
+
+/obj/item/grenade/random/Initialize(mapload)
+    ..()
+    var/obj/item/grenade/randnade = pick(/obj/item/grenade/empgrenade,
+		/obj/item/grenade/stingbang,
+		/obj/item/grenade/plastic/c4,
+		/obj/item/grenade/frag/mega,
+		/obj/item/grenade/gluon,
+		/obj/item/grenade/syndieminibomb,
+		/obj/item/grenade/discogrenade,
+		/obj/item/hot_potato/syndicate,
+		/obj/item/grenade/chem_grenade/ez_clean, //acid foam
+		/obj/item/grenade/chem_grenade/holy,
+		/obj/item/grenade/chem_grenade/teargas/moustache,
+		/obj/item/grenade/clusterbuster,
+		/obj/item/grenade/clusterbuster/syndieminibomb)
+    new randnade(loc)
+    return INITIALIZE_HINT_QDEL
 
 /obj/item/storage/toolbox/ammo/royale
     name = "ammo box"
@@ -596,6 +627,7 @@
 /obj/item/reagent_containers/syringe/bluespace/randtox/Initialize(mapload)
 	list_reagents = list(pick(subtypesof(/datum/reagent/toxin)) = volume)
 	. = ..()
+
 
 /obj/item/dnainjector/random/Initialize(mapload)
     ..()

--- a/code/game/gamemodes/battleroyale/royale.dm
+++ b/code/game/gamemodes/battleroyale/royale.dm
@@ -95,9 +95,10 @@
 
 /obj/item/storage/box/loadout/explosives/PopulateContents()
     var/scaling = length(GLOB.player_list)
-    var/count = 1
+    var/count = 2
     new /obj/item/grenade/plastic/c4/x4(src)
-    while(scaling >= 8 && count < 5)
+    new /obj/item/grenade/plastic/c4/x4(src)
+    while(scaling >= 12 && count < 5)
         new /obj/item/grenade/plastic/c4/x4(src)
         scaling -= 8
         count++
@@ -117,16 +118,15 @@
     var/obj/item/grenade/randnade = pick(/obj/item/grenade/empgrenade,
 		/obj/item/grenade/stingbang,
 		/obj/item/grenade/plastic/c4,
-		/obj/item/grenade/frag/mega,
-		/obj/item/grenade/gluon,
 		/obj/item/grenade/syndieminibomb,
-		/obj/item/grenade/discogrenade,
-		/obj/item/hot_potato/syndicate,
+        /obj/item/grenade/chem_grenade/holy,
+        /obj/item/grenade/smokebomb,
+		/obj/item/grenade/gluon,
+		/obj/item/grenade/flashbang,
+        /obj/item/grenade/frag,
 		/obj/item/grenade/chem_grenade/ez_clean, //acid foam
-		/obj/item/grenade/chem_grenade/holy,
-		/obj/item/grenade/chem_grenade/teargas/moustache,
-		/obj/item/grenade/clusterbuster,
-		/obj/item/grenade/clusterbuster/syndieminibomb)
+        /obj/item/grenade/chem_grenade/metalfoam,
+        )
     new randnade(loc)
     return INITIALIZE_HINT_QDEL
 
@@ -627,7 +627,6 @@
 /obj/item/reagent_containers/syringe/bluespace/randtox/Initialize(mapload)
 	list_reagents = list(pick(subtypesof(/datum/reagent/toxin)) = volume)
 	. = ..()
-
 
 /obj/item/dnainjector/random/Initialize(mapload)
     ..()

--- a/code/game/objects/items/grenades/_grenade.dm
+++ b/code/game/objects/items/grenades/_grenade.dm
@@ -41,6 +41,14 @@
 	var/shrapnel_radius
 	var/shrapnel_initialized
 
+/obj/item/grenade/Initialize(mapload)
+	. = ..()
+	GLOB.grenades += src
+
+/obj/item/grenade/Destroy()
+	GLOB.grenades.Remove(src)
+	return ..()
+
 /obj/item/grenade/suicide_act(mob/living/carbon/user)
 	user.visible_message("<span class='suicide'>[user] primes [src], then eats it! It looks like [user.p_theyre()] trying to commit suicide!</span>")
 	playsound(src, 'sound/items/eatfood.ogg', 50, 1)

--- a/code/modules/admin/battle_royale.dm
+++ b/code/modules/admin/battle_royale.dm
@@ -162,6 +162,8 @@ GLOBAL_LIST_INIT(battle_royale_basic_loot, list(
 		/obj/item/grenade/clusterbuster/emp,
 		/obj/item/grenade/clusterbuster/syndieminibomb,
 		/obj/item/grenade/clusterbuster/spawner_spesscarp,
+		/obj/item/red_button,
+		/obj/item/red_button,
 //Xenobio crossbreed boxes
 		/obj/item/storage/box/royale/random_slimes,
 		/obj/item/storage/box/royale/random_slimes,

--- a/code/modules/assembly/signaler.dm
+++ b/code/modules/assembly/signaler.dm
@@ -81,8 +81,6 @@
 	var/list/data = list()
 	data["frequency"] = frequency
 	data["code"] = code
-	data["minFrequency"] = MIN_FREE_FREQ
-	data["maxFrequency"] = MAX_FREE_FREQ
 	data["connection"] = !!radio_connection
 	return data
 
@@ -93,10 +91,6 @@
 	switch(action)
 		if("signal")
 			INVOKE_ASYNC(src, PROC_REF(signal))
-			. = TRUE
-		if("freq")
-			var/new_frequency = sanitize_frequency(unformat_frequency(params["freq"]), TRUE)
-			set_frequency(new_frequency)
 			. = TRUE
 		if("code")
 			code = text2num(params["code"])

--- a/code/modules/client/loadout/loadout_equipment.dm
+++ b/code/modules/client/loadout/loadout_equipment.dm
@@ -122,9 +122,14 @@
 // UTILITY AND CONSUMABLES
 
 /datum/gear/equipment/explosives
-    display_name = "box of explosives"
+    display_name = "box of X4"
     path = /obj/item/storage/box/loadout/explosives
-    description = "Contains multiple X4 to use in creative ways"
+    description = "Contains multiple X4 to use in creative ways. Exact quantity varies with number of combatants."
+
+/datum/gear/equipment/grenades
+    display_name = "box of grenades"
+    path = /obj/item/storage/box/loadout/grenades
+    description = "Contains an assortment of grenades. Exact quantity varies with number of combatants."
 
 /datum/gear/equipment/bluespace
     display_name = "bluespace crystals"

--- a/code/modules/modular_computers/file_system/programs/signaller.dm
+++ b/code/modules/modular_computers/file_system/programs/signaller.dm
@@ -33,8 +33,6 @@
 	if(sensor?.check_functionality())
 		data["frequency"] = signal_frequency
 		data["code"] = signal_code
-		data["minFrequency"] = MIN_FREE_FREQ
-		data["maxFrequency"] = MAX_FREE_FREQ
 	data["connection"] = !!radio_connection
 	return data
 

--- a/tgui/packages/tgui/interfaces/Signaler.js
+++ b/tgui/packages/tgui/interfaces/Signaler.js
@@ -20,8 +20,6 @@ export const SignalerContent = (props, context) => {
   const {
     code,
     frequency,
-    minFrequency,
-    maxFrequency,
     connection,
   } = data;
   return (
@@ -36,8 +34,6 @@ export const SignalerContent = (props, context) => {
             unit="kHz"
             step={0.2}
             stepPixelSize={6}
-            minValue={minFrequency / 10}
-            maxValue={maxFrequency / 10}
             value={frequency / 10}
             format={value => toFixed(value, 1)}
             width="80px"
@@ -65,7 +61,7 @@ export const SignalerContent = (props, context) => {
             step={1}
             stepPixelSize={6}
             minValue={1}
-            maxValue={100}
+            maxValue={20}
             value={code}
             width="80px"
             onDrag={(e, value) => act('code', {


### PR DESCRIPTION
## About The Pull Request

* Signalers now have 20 possible signals, to make brute forcing codes a possibility, and also to give a chance for players to overlap signals. 
* Adds a new single-use crate item: The big red button. It primes every `obj/item/grenade` currently in the game with a timer of 5 to 15 seconds. The grenades give warning both audibly and in chat so players can do their best to avoid them.
* Adds a new loadout item: **Box of grenades**. Contains 2-8 random grenades, scaling with population up to 24 players.
* Implements this same scaling to the box of X4. It now contains 2-5 scaling up to 36 players.
