### PR TITLE
Halves podperson healing

### DIFF
--- a/code/modules/mob/living/carbon/human/species_types/podpeople.dm
+++ b/code/modules/mob/living/carbon/human/species_types/podpeople.dm
@@ -35,9 +35,7 @@
 		if(H.nutrition > NUTRITION_LEVEL_ALMOST_FULL)
 			H.set_nutrition(NUTRITION_LEVEL_ALMOST_FULL)
 		if(light_amount > 0.2) //if there's enough light, heal
-			H.heal_overall_damage(1,1, 0, BODYTYPE_ORGANIC)
-			H.adjustToxLoss(-1)
-			H.adjustOxyLoss(-1)
+			H.heal_overall_damage(0.5,0.5, 0, BODYTYPE_ORGANIC)
 
 	if(H.nutrition < NUTRITION_LEVEL_STARVING + 50)
 		H.take_overall_damage(2,0)


### PR DESCRIPTION
## About The Pull Request

* Podpeople now heal brute/burn damage at half the speed in light
* Podpeople no longer heal tox or oxyloss

## Why It's Good For The Game

* Considering how easy it is to be in a well lit place, it's quite a bit of a powerful ability. I don't feel like the burn weakness is enough to counteract it after playing as one for several rounds now, and this brings them more in line with the other regenerative race, shadowpeople. 


## Changelog
:cl:
balance: Podpeople's regenerative abilities for being exposed to light have been halved for brute and burn damage, and they have entirely lost the ability to heal toxin damage from just exposure to light.
/:cl:
