### PR TITLE
Players now slowly regenerate in soft-crit

### DIFF
--- a/code/modules/mob/living/carbon/life.dm
+++ b/code/modules/mob/living/carbon/life.dm
@@ -109,7 +109,10 @@
 			losebreath++  //You can't breath at all when in critical or when being choked, so you're going to miss a breath
 
 		else if(health <= crit_threshold)
-			losebreath += 0.25 //You're having trouble breathing in soft crit, so you'll miss a breath one in four times
+			if(prob(25))
+				adjustBruteLoss(-1)
+				adjustFireLoss(-1)
+				adjustToxLoss(-1)
 
 	//Suffocate
 	if(losebreath >= 1) //You've missed a breath, take oxy damage


### PR DESCRIPTION
## About The Pull Request

* Players in soft crit that are still able to breathe now have a 25% chance of recovering 1 of each brute, burn and tox damage. Players in hard crit do not regenerate and still suffocate. 

## Why It's Good For The Game

* Allows fighters who haven't been finished off a slim chance at getting back into the fight. Discourages trying to indefinitely subdue and stall. 


## Testing Photographs and Procedure

I tested it 👍 

## Changelog
:cl:
tweak: players in soft-crit ca
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
