### PR TITLE
Deaths relayed to OOC + Better round-end

### DIFF
--- a/code/__HELPERS/roundend.dm
+++ b/code/__HELPERS/roundend.dm
@@ -738,12 +738,5 @@
 //    discordmsg += "Escapees: [escapees]\n"
     discordmsg += "Integrity: [integrity]\n"
 //    discordmsg += "Gamemode: [SSticker.mode.name]\n"
-    var/list/ded = SSblackbox.first_death
-    if(ded)
-        discordmsg += "First Death: [ded["name"]], [ded["role"]], at [ded["area"]]\n"
-        var/last_words = ded["last_words"] ? "Their last words were: \"[ded["last_words"]]\"\n" : "They had no last words.\n"
-        discordmsg += "[last_words]\n"
-    else
-        discordmsg += "Nobody died!\n"
 //    discordmsg += "--------------------------------------\n"
     sendooc2tgs(discordmsg)

--- a/code/__HELPERS/roundend.dm
+++ b/code/__HELPERS/roundend.dm
@@ -727,11 +727,11 @@
 		qdel(query_check_everything_ranks)
 
 
-/datum/controller/subsystem/ticker/proc/sendtodiscord(var/survivors, var/escapees, var/integrity, var/mob/winner)
+/datum/controller/subsystem/ticker/proc/sendtodiscord(var/survivors, var/escapees, var/integrity)
     var/discordmsg = ""
     discordmsg += "--------------ROUND END--------------\n"
 //    discordmsg += "Server: [CONFIG_GET(string/servername)]\n"
-    discordmsg += "**_[winner ? "[winner.real_name] has claimed victory" : "Everybody died"]!_**\n"
+    discordmsg += "**_[mode.winner ? "[mode.winner.real_name] has claimed victory" : "Everybody died"]!_**\n"
     discordmsg += "Round Number: [GLOB.round_id]\n"
     discordmsg += "Duration: [DisplayTimeText(world.time - SSticker.round_start_time)]\n"
     discordmsg += "Players: [GLOB.player_list.len]\n"

--- a/code/__HELPERS/roundend.dm
+++ b/code/__HELPERS/roundend.dm
@@ -730,7 +730,7 @@
 /datum/controller/subsystem/ticker/proc/sendtodiscord(var/survivors, var/escapees, var/integrity)
     var/discordmsg = ""
     discordmsg += "--------------ROUND END--------------\n"
-    discordmsg += "Server: [CONFIG_GET(string/servername)]\n"
+//    discordmsg += "Server: [CONFIG_GET(string/servername)]\n"
     discordmsg += "Round Number: [GLOB.round_id]\n"
     discordmsg += "Duration: [DisplayTimeText(world.time - SSticker.round_start_time)]\n"
     discordmsg += "Players: [GLOB.player_list.len]\n"

--- a/code/__HELPERS/roundend.dm
+++ b/code/__HELPERS/roundend.dm
@@ -734,17 +734,10 @@
     discordmsg += "Round Number: [GLOB.round_id]\n"
     discordmsg += "Duration: [DisplayTimeText(world.time - SSticker.round_start_time)]\n"
     discordmsg += "Players: [GLOB.player_list.len]\n"
-    discordmsg += "Survivors: [survivors]\n"
-    discordmsg += "Escapees: [escapees]\n"
+//    discordmsg += "Survivors: [survivors]\n"
+//    discordmsg += "Escapees: [escapees]\n"
     discordmsg += "Integrity: [integrity]\n"
-    discordmsg += "Gamemode: [SSticker.mode.name]\n"
-    if(istype(SSticker.mode, /datum/game_mode/dynamic))
-        var/datum/game_mode/dynamic/mode = SSticker.mode
-        discordmsg += "Threat level: [mode.threat_level]\n"
-        discordmsg += "Threat left: [mode.mid_round_budget]\n"
-        discordmsg += "Executed rules:\n"
-        for(var/datum/dynamic_ruleset/rule in mode.executed_rules)
-            discordmsg += "[rule.ruletype] - [rule.name]: -[rule.cost + rule.scaled_times * rule.scaling_cost] threat\n"
+//    discordmsg += "Gamemode: [SSticker.mode.name]\n"
     var/list/ded = SSblackbox.first_death
     if(ded)
         discordmsg += "First Death: [ded["name"]], [ded["role"]], at [ded["area"]]\n"
@@ -752,5 +745,5 @@
         discordmsg += "[last_words]\n"
     else
         discordmsg += "Nobody died!\n"
-    discordmsg += "--------------------------------------\n"
+//    discordmsg += "--------------------------------------\n"
     sendooc2tgs(discordmsg)

--- a/code/__HELPERS/roundend.dm
+++ b/code/__HELPERS/roundend.dm
@@ -727,10 +727,11 @@
 		qdel(query_check_everything_ranks)
 
 
-/datum/controller/subsystem/ticker/proc/sendtodiscord(var/survivors, var/escapees, var/integrity)
+/datum/controller/subsystem/ticker/proc/sendtodiscord(var/survivors, var/escapees, var/integrity, var/mob/winner)
     var/discordmsg = ""
     discordmsg += "--------------ROUND END--------------\n"
 //    discordmsg += "Server: [CONFIG_GET(string/servername)]\n"
+    discordmsg += "**_[winner ? "[winner.real_name] has claimed victory" : "Everybody died"]!_**\n"
     discordmsg += "Round Number: [GLOB.round_id]\n"
     discordmsg += "Duration: [DisplayTimeText(world.time - SSticker.round_start_time)]\n"
     discordmsg += "Players: [GLOB.player_list.len]\n"
@@ -738,5 +739,5 @@
 //    discordmsg += "Escapees: [escapees]\n"
     discordmsg += "Integrity: [integrity]\n"
 //    discordmsg += "Gamemode: [SSticker.mode.name]\n"
-//    discordmsg += "--------------------------------------\n"
+    discordmsg += "--------------------------------------\n"
     sendooc2tgs(discordmsg)

--- a/code/controllers/master.dm
+++ b/code/controllers/master.dm
@@ -202,7 +202,7 @@ GLOBAL_REAL(Master, /datum/controller/master) = new
 		init_subtypes(/datum/controller/subsystem, subsystems)
 
 	to_chat(world, "<span class='boldannounce'>Initializing subsystems...</span>")
-	send2chat("\<@&1089489378264490095\>\nNew round starting on [SSmapping.config.map_name]!", CONFIG_GET(string/chat_announce_new_game))
+	send2chat("\<@&1089489378264490095\>\nNew round loading up now!", CONFIG_GET(string/chat_announce_new_game))
 
 	// Sort subsystems by init_order, so they initialize in the correct order.
 	sortTim(subsystems, GLOBAL_PROC_REF(cmp_subsystem_init))

--- a/code/controllers/master.dm
+++ b/code/controllers/master.dm
@@ -202,7 +202,7 @@ GLOBAL_REAL(Master, /datum/controller/master) = new
 		init_subtypes(/datum/controller/subsystem, subsystems)
 
 	to_chat(world, "<span class='boldannounce'>Initializing subsystems...</span>")
-	send2chat("\<@&1089489378264490095\>\nNew round loading up now!", CONFIG_GET(string/chat_announce_new_game))
+	send2chat("New round loading up now!", CONFIG_GET(string/chat_announce_new_game))
 
 	// Sort subsystems by init_order, so they initialize in the correct order.
 	sortTim(subsystems, GLOBAL_PROC_REF(cmp_subsystem_init))

--- a/code/controllers/master.dm
+++ b/code/controllers/master.dm
@@ -202,7 +202,7 @@ GLOBAL_REAL(Master, /datum/controller/master) = new
 		init_subtypes(/datum/controller/subsystem, subsystems)
 
 	to_chat(world, "<span class='boldannounce'>Initializing subsystems...</span>")
-	send2chat("New round loading up now!", CONFIG_GET(string/chat_announce_new_game))
+	send2chat("<@&1089489378264490095>\nNew round loading up now!", CONFIG_GET(string/chat_announce_new_game))
 
 	// Sort subsystems by init_order, so they initialize in the correct order.
 	sortTim(subsystems, GLOBAL_PROC_REF(cmp_subsystem_init))

--- a/code/controllers/master.dm
+++ b/code/controllers/master.dm
@@ -202,7 +202,6 @@ GLOBAL_REAL(Master, /datum/controller/master) = new
 		init_subtypes(/datum/controller/subsystem, subsystems)
 
 	to_chat(world, "<span class='boldannounce'>Initializing subsystems...</span>")
-	send2chat("<@&1089489378264490095> <byond://play.royalestation13.com:1337>\nNew round loading up now!", CONFIG_GET(string/chat_announce_new_game))
 
 	// Sort subsystems by init_order, so they initialize in the correct order.
 	sortTim(subsystems, GLOBAL_PROC_REF(cmp_subsystem_init))

--- a/code/controllers/master.dm
+++ b/code/controllers/master.dm
@@ -202,7 +202,7 @@ GLOBAL_REAL(Master, /datum/controller/master) = new
 		init_subtypes(/datum/controller/subsystem, subsystems)
 
 	to_chat(world, "<span class='boldannounce'>Initializing subsystems...</span>")
-	send2chat("<@&1089489378264490095>\nNew round loading up now!", CONFIG_GET(string/chat_announce_new_game))
+	send2chat("<@&1089489378264490095> <byond://play.royalestation13.com:1337>\nNew round loading up now!", CONFIG_GET(string/chat_announce_new_game))
 
 	// Sort subsystems by init_order, so they initialize in the correct order.
 	sortTim(subsystems, GLOBAL_PROC_REF(cmp_subsystem_init))

--- a/code/controllers/master.dm
+++ b/code/controllers/master.dm
@@ -202,6 +202,7 @@ GLOBAL_REAL(Master, /datum/controller/master) = new
 		init_subtypes(/datum/controller/subsystem, subsystems)
 
 	to_chat(world, "<span class='boldannounce'>Initializing subsystems...</span>")
+	send2chat("\<@&1089489378264490095\>\nNew round starting on [SSmapping.config.map_name]!", CONFIG_GET(string/chat_announce_new_game))
 
 	// Sort subsystems by init_order, so they initialize in the correct order.
 	sortTim(subsystems, GLOBAL_PROC_REF(cmp_subsystem_init))

--- a/code/controllers/subsystem/ticker.dm
+++ b/code/controllers/subsystem/ticker.dm
@@ -343,6 +343,7 @@ SUBSYSTEM_DEF(ticker)
 	SSdbcore.SetRoundStart()
 
 	to_chat(world, "<h2><B>Welcome to [station_name()], Happy killing!</B></h2>")
+	send2chat("New round starting on [SSmapping.config.map_name]!", CONFIG_GET(string/chat_announce_new_game))
 	if(prob(15))
 		var/song = rand(1, 3)
 		switch(song)

--- a/code/controllers/subsystem/ticker.dm
+++ b/code/controllers/subsystem/ticker.dm
@@ -343,7 +343,7 @@ SUBSYSTEM_DEF(ticker)
 	SSdbcore.SetRoundStart()
 
 	to_chat(world, "<h2><B>Welcome to [station_name()], Happy killing!</B></h2>")
-	send2chat("New round starting on [SSmapping.config.map_name]!", CONFIG_GET(string/chat_announce_new_game))
+	send2chat("<@&1089489378264490095> <byond://play.royalestation13.com:1337>\nNew round starting on [SSmapping.config.map_name] with [length(GLOB.player_list)] players online!", CONFIG_GET(string/chat_announce_new_game))
 	if(prob(15))
 		var/song = rand(1, 3)
 		switch(song)

--- a/code/controllers/subsystem/ticker.dm
+++ b/code/controllers/subsystem/ticker.dm
@@ -157,7 +157,6 @@ SUBSYSTEM_DEF(ticker)
 			for(var/client/C in GLOB.clients)
 				window_flash(C, ignorepref = TRUE) //let them know lobby has opened up.
 			to_chat(world, "<span class='boldnotice'>Welcome to [station_name()]!</span>")
-			send2chat("New round starting on [SSmapping.config.map_name]!", CONFIG_GET(string/chat_announce_new_game))
 			current_state = GAME_STATE_PREGAME
 			//Everyone who wants to be an observer is now spawned
 			create_observers()
@@ -344,6 +343,7 @@ SUBSYSTEM_DEF(ticker)
 	SSdbcore.SetRoundStart()
 
 	to_chat(world, "<h2><B>Welcome to [station_name()], Happy killing!</B></h2>")
+	send2chat("New round starting on [SSmapping.config.map_name]!", CONFIG_GET(string/chat_announce_new_game))
 	if(prob(15))
 		var/song = rand(1, 3)
 		switch(song)

--- a/code/controllers/subsystem/ticker.dm
+++ b/code/controllers/subsystem/ticker.dm
@@ -343,7 +343,6 @@ SUBSYSTEM_DEF(ticker)
 	SSdbcore.SetRoundStart()
 
 	to_chat(world, "<h2><B>Welcome to [station_name()], Happy killing!</B></h2>")
-	send2chat("New round starting on [SSmapping.config.map_name]!", CONFIG_GET(string/chat_announce_new_game))
 	if(prob(15))
 		var/song = rand(1, 3)
 		switch(song)

--- a/code/game/gamemodes/battleroyale/royale.dm
+++ b/code/game/gamemodes/battleroyale/royale.dm
@@ -67,11 +67,11 @@
 /datum/game_mode/battle_royale/special_report()
     if(winner == "draw")
         to_chat(world, "<span class='ratvar'><font size=12>Everybody died!</font></span>")
-        sendooc2tgs("**Everybody died!**\n--------------------------------------")
+        sendooc2tgs("**_Everybody died!_**")
         return "<div class='panel redborder'><span class='redtext big'>Nobody claims victory!</span></div>"
     if(winner?.real_name)
         to_chat(world, "<span class='ratvar'><font size=12>[winner.real_name] claims victory!</font></span>")
-        sendooc2tgs("**[winner.real_name] has claimed victory!**\n--------------------------------------")
+        sendooc2tgs("**_[winner.real_name] has claimed victory!_**")
         return "<div class='panel redborder'><span class='greentext big'>[winner.real_name] claims victory!</span></div>"
     else
         to_chat(world, "<span class='ratvar'><font size=12>Something is bugged!</font></span>")

--- a/code/game/gamemodes/battleroyale/royale.dm
+++ b/code/game/gamemodes/battleroyale/royale.dm
@@ -12,7 +12,6 @@
         <span class='notice'>Loot drops will periodically rain from the sky in random locations</span>\n\
         <span class='notice'>Random events will keep things spicy from time to time, stay on your toes!</span>\n\
 	    <span class='danger'>Mild banter is fine, but don't be toxic to others unless you want to be smited</span>"
-    var/mob/winner
     var/debug_announce
 
 /datum/game_mode/battle_royale/post_setup()
@@ -67,11 +66,9 @@
 /datum/game_mode/battle_royale/special_report()
     if(winner == "draw")
         to_chat(world, "<span class='ratvar'><font size=12>Everybody died!</font></span>")
-        sendooc2tgs("**_Everybody died!_**")
         return "<div class='panel redborder'><span class='redtext big'>Nobody claims victory!</span></div>"
     if(winner?.real_name)
         to_chat(world, "<span class='ratvar'><font size=12>[winner.real_name] claims victory!</font></span>")
-        sendooc2tgs("**_[winner.real_name] has claimed victory!_**")
         return "<div class='panel redborder'><span class='greentext big'>[winner.real_name] claims victory!</span></div>"
     else
         to_chat(world, "<span class='ratvar'><font size=12>Something is bugged!</font></span>")

--- a/code/game/gamemodes/battleroyale/royale.dm
+++ b/code/game/gamemodes/battleroyale/royale.dm
@@ -51,6 +51,7 @@
 /datum/game_mode/battle_royale/check_finished()
     if(winner)
         if(winner == "draw")
+            winner = null //go back to being null for outside purposes - there is no winner to announce.
             return TRUE //Everyone is dead, we end regardless of debug mode or not
         if(debug_announce)
             return FALSE //We have announced debug mode and someone is still alive. Keep going
@@ -64,7 +65,7 @@
             return TRUE
 
 /datum/game_mode/battle_royale/special_report()
-    if(winner == "draw")
+    if(!winner)
         to_chat(world, "<span class='ratvar'><font size=12>Everybody died!</font></span>")
         return "<div class='panel redborder'><span class='redtext big'>Nobody claims victory!</span></div>"
     if(winner?.real_name)

--- a/code/game/gamemodes/battleroyale/royale.dm
+++ b/code/game/gamemodes/battleroyale/royale.dm
@@ -67,9 +67,11 @@
 /datum/game_mode/battle_royale/special_report()
     if(winner == "draw")
         to_chat(world, "<span class='ratvar'><font size=12>Everybody died!</font></span>")
+        sendooc2tgs("**Everybody died!**\n--------------------------------------")
         return "<div class='panel redborder'><span class='redtext big'>Nobody claims victory!</span></div>"
     if(winner?.real_name)
         to_chat(world, "<span class='ratvar'><font size=12>[winner.real_name] claims victory!</font></span>")
+        sendooc2tgs("**[winner.real_name] has claimed victory!**\n--------------------------------------")
         return "<div class='panel redborder'><span class='greentext big'>[winner.real_name] claims victory!</span></div>"
     else
         to_chat(world, "<span class='ratvar'><font size=12>Something is bugged!</font></span>")

--- a/code/game/gamemodes/game_mode.dm
+++ b/code/game/gamemodes/game_mode.dm
@@ -53,6 +53,7 @@
 
 	var/gamemode_ready = FALSE //Is the gamemode all set up and ready to start checking for ending conditions.
 	var/setup_error		//What stopepd setting up the mode.
+	var/mob/winner
 
 	/// Associative list of current players, in order: living players, living antagonists, dead players and observers.
 	var/list/list/current_players = list(CURRENT_LIVING_PLAYERS = list(), CURRENT_LIVING_ANTAGS = list(), CURRENT_DEAD_PLAYERS = list(), CURRENT_OBSERVERS = list())

--- a/code/modules/mob/living/death.dm
+++ b/code/modules/mob/living/death.dm
@@ -61,7 +61,7 @@
 			deadchat_broadcast(rendered, follow_target = src, turf_target = T, message_type=DEADCHAT_DEATHRATTLE)
 			SEND_SOUND(world, sound('sound/misc/player_eliminated.ogg'))
 			to_chat(world, "<span class='danger'><b>[mind.name]</b> has been eliminated</b>.</span>")
-			var/deathgasp = last_words ? " *In their dying breath they said:\"[last_words]\"*" : ""
+			var/deathgasp = last_words ? " *In their dying breath they said: \"[last_words]\"*" : ""
 			sendooc2tgs("(DEATH) **[mind.name]** has been eliminated[deathgasp]")
 		mind.store_memory("Time of death: [tod]", 0)
 	remove_from_alive_mob_list()

--- a/code/modules/mob/living/death.dm
+++ b/code/modules/mob/living/death.dm
@@ -61,6 +61,8 @@
 			deadchat_broadcast(rendered, follow_target = src, turf_target = T, message_type=DEADCHAT_DEATHRATTLE)
 			SEND_SOUND(world, sound('sound/misc/player_eliminated.ogg'))
 			to_chat(world, "<span class='danger'><b>[mind.name]</b> has been eliminated</b>.</span>")
+			var/deathgasp = last_words ? " In their dying breath they said:\"[last_words]\"" : ""
+			sendooc2tgs("[mind.name] has been eliminated.[deathgasp]")
 		mind.store_memory("Time of death: [tod]", 0)
 	remove_from_alive_mob_list()
 	if(playable)

--- a/code/modules/mob/living/death.dm
+++ b/code/modules/mob/living/death.dm
@@ -61,8 +61,8 @@
 			deadchat_broadcast(rendered, follow_target = src, turf_target = T, message_type=DEADCHAT_DEATHRATTLE)
 			SEND_SOUND(world, sound('sound/misc/player_eliminated.ogg'))
 			to_chat(world, "<span class='danger'><b>[mind.name]</b> has been eliminated</b>.</span>")
-			var/deathgasp = last_words ? " *In their dying breath they said: \"[last_words]\"*" : ""
-			sendooc2tgs("(DEATH) **[mind.name]** has been eliminated[deathgasp]")
+			var/deathgasp = last_words ? " *In their dying breath they said:* **_\"[last_words]\"_**" : ""
+			sendooc2tgs("(DEATH) **[mind.name]** has been eliminated.[deathgasp]")
 		mind.store_memory("Time of death: [tod]", 0)
 	remove_from_alive_mob_list()
 	if(playable)

--- a/code/modules/mob/living/death.dm
+++ b/code/modules/mob/living/death.dm
@@ -61,8 +61,8 @@
 			deadchat_broadcast(rendered, follow_target = src, turf_target = T, message_type=DEADCHAT_DEATHRATTLE)
 			SEND_SOUND(world, sound('sound/misc/player_eliminated.ogg'))
 			to_chat(world, "<span class='danger'><b>[mind.name]</b> has been eliminated</b>.</span>")
-			var/deathgasp = last_words ? " In their dying breath they said:\"[last_words]\"" : ""
-			sendooc2tgs("[mind.name] has been eliminated.[deathgasp]")
+			var/deathgasp = last_words ? " *In their dying breath they said:\"[last_words]\"*" : ""
+			sendooc2tgs("(DEATH) **[mind.name]** has been eliminated[deathgasp]")
 		mind.store_memory("Time of death: [tod]", 0)
 	remove_from_alive_mob_list()
 	if(playable)


### PR DESCRIPTION
## About The Pull Request

* Deaths are relayed to OOC as they occur
* Round end message has had some useless information cut and now announces the winner

## Why It's Good For The Game

* Relaying live reports to discord can help draw attention to active rounds

## Testing Photographs and Procedure

* To be tested on live server

## Changelog
:cl:
add: Deaths and last words are now relayed to the discord server in realtime
tweak: Round-end discord reports have been modified to better suit the server
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
