### PR TITLE
Fix multiz wall and enable glowstation

### DIFF
--- a/code/modules/admin/battle_royale.dm
+++ b/code/modules/admin/battle_royale.dm
@@ -515,17 +515,18 @@ GLOBAL_DATUM(battle_royale, /datum/battle_royale_controller)
 	addtimer(CALLBACK(src, PROC_REF(generate_basic_loot), GLOB.player_list.len), 300)
 
 	death_wall = list()
-	var/z_level = SSmapping.station_start
-	var/turf/center = SSmapping.get_station_center()
-	var/list/edge_turfs = list()
-	edge_turfs += block(locate(1, 1, z_level), locate(255, 1, z_level))			//BOTTOM
-	edge_turfs += block(locate(1, 255, z_level), locate(255, 255, z_level))		//TOP
-	edge_turfs |= block(locate(1, 1, z_level), locate(1, 255, z_level))			//LEFT
-	edge_turfs |= block(locate(255, 1, z_level), locate(255, 255, z_level)) 	//RIGHT
-	for(var/turf/T in edge_turfs)
-		var/obj/effect/death_wall/DW = new(T)
-		DW.set_center(center)
-		death_wall += DW
+	for(var/z_level in SSmapping.levels_by_trait(ZTRAIT_STATION))
+		var/turf/center = SSmapping.get_station_center(level = z_level)
+		var/list/edge_turfs = list()
+		edge_turfs += block(locate(1, 1, z_level), locate(255, 1, z_level))			//BOTTOM
+		edge_turfs += block(locate(1, 255, z_level), locate(255, 255, z_level))		//TOP
+		edge_turfs |= block(locate(1, 1, z_level), locate(1, 255, z_level))			//LEFT
+		edge_turfs |= block(locate(255, 1, z_level), locate(255, 255, z_level)) 	//RIGHT
+		for(var/turf/T in edge_turfs)
+			var/obj/effect/death_wall/DW = new(T)
+			DW.set_center(center)
+			death_wall += DW
+			CHECK_TICK
 		CHECK_TICK
 	START_PROCESSING(SSprocessing, src)
 

--- a/code/modules/mapping/space_management/traits.dm
+++ b/code/modules/mapping/space_management/traits.dm
@@ -68,6 +68,5 @@
 	return locate(T.x, T.y, T.z + offset)
 
 // Prefer not to use this one too often
-/datum/controller/subsystem/mapping/proc/get_station_center()
-	var/station_z = levels_by_trait(ZTRAIT_STATION)[1]
-	return locate(round(world.maxx * 0.5, 1), round(world.maxy * 0.5, 1), station_z)
+/datum/controller/subsystem/mapping/proc/get_station_center(level = levels_by_trait(ZTRAIT_STATION)[1])
+	return locate(round(world.maxx * 0.5, 1), round(world.maxy * 0.5, 1), level)

--- a/config/maps.txt
+++ b/config/maps.txt
@@ -54,7 +54,9 @@ map kilostation
 endmap
 
 map glowstation
-	disabled
+	minplayers 30
+	maxplayers 200
+	votable
 endmap
 
 map flandstation


### PR DESCRIPTION
## About The Pull Request

Glow is really only a problem because the wall only shows on z1. This makes it show on all station zs.

## Why It's Good For The Game

More maps cool, also multiz support.

## Testing Photographs and Procedure

<details>
<summary>Screenshots&Videos</summary>

![image](https://user-images.githubusercontent.com/10366817/228724163-9412c861-1327-41f7-8034-6a5b5d3c1de0.png)
![image](https://user-images.githubusercontent.com/10366817/228724166-1cb62cfe-3f4a-4cfe-90f5-931ebc496cb2.png)

</details>

## Changelog
:cl:
fix: Fixed wall only showing on the first station z.
config: Enabled GlowStation.
/:cl:
