### PR TITLE
Holoparasite fix + loadout syringes

### DIFF
--- a/code/game/gamemodes/battleroyale/royale.dm
+++ b/code/game/gamemodes/battleroyale/royale.dm
@@ -25,7 +25,7 @@
     var/list/active_players = list()
 
     for(var/mob/living/player in player_list) //checking for all living mobs instead of just humans
-        if((!player.client) || (is_centcom_level(player.z) || isrevenant(player) || istype(player, /mob/living/carbon/human/species/shadow/nightmare) || istype(player, /mob/living/simple_animal/bot/secbot) || player.ventcrawler))
+        if((!player.client) || (is_centcom_level(player.z) || isrevenant(player) || istype(player, /mob/living/carbon/human/species/shadow/nightmare) || istype(player, /mob/living/simple_animal/bot/secbot) || istype(player, /mob/living/simple_animal/hostile/guardian) || player.ventcrawler))
             continue
         if(istype(player.loc, /obj/structure/closet/supplypod/centcompod))
             continue

--- a/code/modules/client/loadout/loadout_equipment.dm
+++ b/code/modules/client/loadout/loadout_equipment.dm
@@ -170,6 +170,10 @@
     path = /obj/item/reagent_containers/hypospray/medipen/survival
     description = "A medipen for surviving in the harshest of environments, heals and protects from environmental hazards."
 
+/datum/gear/equipment/syringes
+    display_name = "box of syringes"
+    path = /obj/item/storage/box/royale/unlabeled_syringes
+
 //ARMOR (mostly cloaks, really)
 
 /datum/gear/equipment/armor


### PR DESCRIPTION
## About The Pull Request

* Holoparasites no longer count as combatants so someone using one can actually win
* A new loadout item has been added: Box of syringes. The syringes contain almost any reagent and have no labels.

## Why It's Good For The Game
* Bug fix
* Random syringes seem about in line with other loadout items

## Changelog
:cl:
add: Added a new loadout item: A box of random, unlabeled syringes
fix: fixed holoparasites counting as combatants
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
