### PR TITLE
Fixes holosword colors from loadout

### DIFF
--- a/code/modules/client/loadout/loadout_equipment.dm
+++ b/code/modules/client/loadout/loadout_equipment.dm
@@ -1,7 +1,7 @@
 /datum/gear/equipment
     subtype_path = /datum/gear/equipment
     sort_category = "Combat Equipment (pick two)"
-    //Players can have any two items listed under this category, unless they are assigned to an equipment slot. 
+    //Players can have any two items listed under this category, unless they are assigned to an equipment slot.
 
 //RANGED WEAPONS
 
@@ -56,11 +56,11 @@
 
 /datum/gear/equipment/holosword/green
     display_name = "green holo sword"
-    path = /obj/item/holo/esword/red
+    path = /obj/item/holo/esword/green
 
 /datum/gear/equipment/holosword/purple
     display_name = "purple holo sword"
-    path = /obj/item/holo/esword/green
+    path = /obj/item/holo/esword/purple
 
 /datum/gear/equipment/holosword/red
     display_name = "red holo sword"


### PR DESCRIPTION
## About The Pull Request

* Fixes purple and green holoswords so they are the correct color

## Why It's Good For The Game

## Changelog
:cl:
fix: Fixes purple and green holoswords so they are the correct color
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
