### PR TITLE
Royale website + github repath

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -43,17 +43,17 @@ You can of course, as always, ask for help on our discord.
 
 In addition to VSCode, several other tools exist to make your life easier.
 
-- Git client - [GitKraken](https://www.gitkraken.com/) or [Command line (recommended)](https://git-scm.com/downloads)
-  - See [Guide to git](https://wiki.beestation13.com/view/Guide_to_git) for more detailed information
-- Code editing - [VSCode](https://code.visualstudio.com/) (NOT THE SAME AS VISUAL STUDIO)
-- VSCode Extensions - You will be prompted to install this recommended extension automatically: [Goonstation Extension Pack](https://marketplace.visualstudio.com/items?itemName=Goonstation.goonstation-extpack)
-- Map editing - [StrongDMM](https://github.com/SpaiR/StrongDMM) or [FastDMM2](https://fastdmm2.ss13.io/). Dream Maker works but requires additional steps for SS13 that these automate.
-- Icon editing - Dream Maker or your image editor of choice. Any PNG can be imported into Dream Maker.
-- Database - MariaDB: [Setup guide](https://wiki.beestation13.com/view/Working_with_the_database#Database_Setup)
+-   Git client - [GitKraken](https://www.gitkraken.com/) or [Command line (recommended)](https://git-scm.com/downloads)
+    -   See [Guide to git](https://wiki.beestation13.com/view/Guide_to_git) for more detailed information
+-   Code editing - [VSCode](https://code.visualstudio.com/) (NOT THE SAME AS VISUAL STUDIO)
+-   VSCode Extensions - You will be prompted to install this recommended extension automatically: [Goonstation Extension Pack](https://marketplace.visualstudio.com/items?itemName=Goonstation.goonstation-extpack)
+-   Map editing - [StrongDMM](https://github.com/SpaiR/StrongDMM) or [FastDMM2](https://fastdmm2.ss13.io/). Dream Maker works but requires additional steps for SS13 that these automate.
+-   Icon editing - Dream Maker or your image editor of choice. Any PNG can be imported into Dream Maker.
+-   Database - MariaDB: [Setup guide](https://wiki.beestation13.com/view/Working_with_the_database#Database_Setup)
 
 ## 4. Code Standards
 
-There are a variety of ways you can write valid DM code. However, BeeStation is not as lenient. Maintaining good code standards is important for performance and readability reasons. You can find details about our code standards [here](https://github.com/Rukofamicom/Royale-Station-13/wiki/Code-Standards).
+There are a variety of ways you can write valid DM code. However, BeeStation is not as lenient. Maintaining good code standards is important for performance and readability reasons. You can find details about our code standards [here](https://github.com/Royale-Station-13/Royale-Station-13/wiki/Code-Standards).
 
 They are mostly the same as /tg/station's code standards, though we are not quite as strict about enforcing them. A notable example is that we don't require our code to be thoroughly documented for autodoc.
 

--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,1 +1,1 @@
-patreon: user?u=10639001
+patreon: user?u=10567200

--- a/README.md
+++ b/README.md
@@ -1,10 +1,13 @@
 <h1 align="center">RoyaleStation 13 Codebase</h1>
 
 [![forthebadge](https://forthebadge.com/images/badges/built-with-resentment.svg)](https://forthebadge.com) [![forthebadge](https://forthebadge.com/images/badges/contains-technical-debt.svg)](https://user-images.githubusercontent.com/8171642/50290880-ffef5500-043a-11e9-8270-a2e5b697c86c.png) [![forinfinityandbyond](https://user-images.githubusercontent.com/5211576/29499758-4efff304-85e6-11e7-8267-62919c3688a9.gif)](https://www.reddit.com/r/SS13/comments/5oplxp/what_is_the_main_problem_with_byond_as_an_engine/dclbu1a)
-[![Build Status](https://github.com/Rukofamicom/Royale-Station-13/workflows/Run%20tests/badge.svg)](https://github.com/Rukofamicom/Royale-Station-13/actions?query=workflow%3A%22Run+tests%22)
-![Open Issues](https://isitmaintained.com/badge/open/Rukofamicom/Royale-Station-13.svg)
+[![Build Status](https://github.com/Royale-Station-13/Royale-Station-13/workflows/Run%20tests/badge.svg)](https://github.com/Royale-Station-13/Royale-Station-13/actions?query=workflow%3A%22Run+tests%22)
+![Open Issues](https://isitmaintained.com/badge/open/Royale-Station-13/Royale-Station-13.svg)
 
-**Code:** https://github.com/Rukofamicom/Royale-Station-13
+**Website:** https://royalestation13.com/
+
+**Code:** https://github.com/Royale-Station-13/Royale-Station-13
+
 **Wiki:** https://wiki.beestation13.com/view/Main_Page
 
 ## DOWNLOADING
@@ -16,7 +19,7 @@ Follow this: https://wiki.beestation13.com/view/Guide_to_git
 Clone the repository using `git clone`.
 
 Option 2: Download the source code as a zip by clicking the ZIP button in the
-code tab of https://github.com/Rukofamicom/Royale-Station-13
+code tab of https://github.com/Royale-Station-13/Royale-Station-13
 (note: this will use a lot of bandwidth if you wish to update and is a lot of
 hassle if you want to make any changes at all, so it's not recommended.)
 

--- a/code/controllers/configuration/entries/general.dm
+++ b/code/controllers/configuration/entries/general.dm
@@ -222,7 +222,7 @@
 	config_entry_value = "https://discord.gg/m5wTK9fxa3"
 
 /datum/config_entry/string/githuburl
-	config_entry_value = "https://github.com/Rukofamicom/Royale-Station-13"
+	config_entry_value = "https://github.com/Royale-Station-13/Royale-Station-13"
 
 /datum/config_entry/string/issue_label
 

--- a/config/config.txt
+++ b/config/config.txt
@@ -279,7 +279,7 @@ GUEST_BAN
 #ISSUE_LABEL Ingame Issue Report
 
 ## Donation URL
-DONATEURL https://ko-fi.com/rukofamicom
+DONATEURL https://www.patreon.com/RoyaleStation13
 
 ## Discord Invite
 DISCORDURL https://discord.gg/m5wTK9fxa3

--- a/config/config.txt
+++ b/config/config.txt
@@ -269,10 +269,10 @@ GUEST_BAN
 #WIKIURL https://wiki.beestation13.com/view
 
 ## Rules address
-#RULESURL https://discord.gg/m5wTK9fxa3
+#RULESURL https://royalestation13.com/rules
 
 ## Github address
-#GITHUBURL https://github.com/Rukofamicom/Royale-Station-13
+#GITHUBURL https://github.com/Royale-Station-13/Royale-Station-13
 
 ## Label to tag ingame-registered issues with.
 ## Uncomment this to enable them.

--- a/config/motd.txt
+++ b/config/motd.txt
@@ -1,6 +1,8 @@
 <h1>Welcome to Royale Station 13!</h1>
+
+<br><b>Website: 	<a href="https://royalestation13.com/">Click Me!</a></b>
 <br><b>Discord: 	<a href="https://discord.gg/m5wTK9fxa3">Click Me!</a></b>
-<br><b>Donate:	<a href="https://ko-fi.com/rukofamicom">Click Me!</a></b>
+<br><b>Donate:	<a href="https://www.patreon.com/RoyaleStation13">Click Me!</a></b>
 
 <b>Change your loadout in preferences to adjust your starting gear</b>
 <b>All jobs have unlimited slots, but mostly only offer different spawn locations</b>

--- a/html/changelog.html
+++ b/html/changelog.html
@@ -23,10 +23,10 @@
 <table align='center' class="top">
 	<tr>
 		<td valign='top'>
-			<div align='center'><font size='3'><b>RoyaleStation 13</b></font></div>
+			<div align='center'><font size='3'><b>Royale Station 13</b></font></div>
 
-			<p><div align='center'><font size='3'><a href="https://beestation13.com/">Site</a> | <a href="https://beestation13.com/forum">Forum</a> | <a href="https://wiki.beestation13.com/">Wiki</a> | <a href="https://github.com/Royale-Station-13/Royale-Station-13">Source</a></font></div></p>
-			<font size='2'><b>Join our Discord </b><a href=https://discord.gg/zUe34rs>Here!</a></font>
+			<p><div align='center'><font size='3'><a href="https://royalestation13.com/">Site</a> | <a href="https://wiki.beestation13.com/">Wiki</a> | <a href="https://github.com/Royale-Station-13/Royale-Station-13">Source</a></font></div></p>
+			<font size='2'><b>Join our Discord </b><a href=https://discord.gg/m5wTK9fxa3>Here!</a></font>
 			</td>
 	</tr>
 </table>

--- a/html/changelog.html
+++ b/html/changelog.html
@@ -25,7 +25,7 @@
 		<td valign='top'>
 			<div align='center'><font size='3'><b>RoyaleStation 13</b></font></div>
 
-			<p><div align='center'><font size='3'><a href="https://beestation13.com/">Site</a> | <a href="https://beestation13.com/forum">Forum</a> | <a href="https://wiki.beestation13.com/">Wiki</a> | <a href="https://github.com/Rukofamicom/Royale-Station-13">Source</a></font></div></p>
+			<p><div align='center'><font size='3'><a href="https://beestation13.com/">Site</a> | <a href="https://beestation13.com/forum">Forum</a> | <a href="https://wiki.beestation13.com/">Wiki</a> | <a href="https://github.com/Royale-Station-13/Royale-Station-13">Source</a></font></div></p>
 			<font size='2'><b>Join our Discord </b><a href=https://discord.gg/zUe34rs>Here!</a></font>
 			</td>
 	</tr>
@@ -35,13 +35,13 @@
 	<tr>
 		<td valign='top'>
 			<font size='2'><b>Current Project Maintainers:</b> <a href='https://github.com/orgs/BeeStation/people'>-Click Here-</a><br></font>
-			<font size='2'><b>Currently Active GitHub contributor list:</b> <a href='https://github.com/Rukofamicom/Royale-Station-13/graphs/contributors'>-Click Here-</a><br></font>
+			<font size='2'><b>Currently Active GitHub contributor list:</b> <a href='https://github.com/Royale-Station-13/Royale-Station-13/graphs/contributors'>-Click Here-</a><br></font>
 			<font size='2'><b>Coders:</b> Agouri, Aranclanos, AzlanonPC, Cael_Aislinn, Carn, Cenrus, Cheridan, ConstantA, Crossedfall, CthulhuOnIce, Darem, Donkie, Doohl, DumpDavidson, Elo001, Errorage, Francinum, Fleure, Giacom, Ikarrus, Intigracy, Kor, MCterra, Malkevin, ManeaterMildred, Mark Suckerberg, Miauw, Mport, MrPerson, NEO, Nodrak, Noise, Noka, Numbers, Petethegoat, Polymorph, PowerfulBacon, Qwertyquerty, Rockdtben, ShadowH4nD, Sieve, Skie, St0rmC4st3r, SuperSayu, Superxpdude, TLE, Tastyfish, Uhangi, Urist McDorf, Yvar, ike709, muskets, rastaf0, trubble_bass, veryinky<br></font>
 			<font size='2'><b>Spriters:</b> Agouri, Ausops, AzlanonPC, Cheridan, CruazyGuest, Deeaych, Deuryn, Firecage, Kor, Matty406, Microwave, Naevi, Nienhaus2, Petethegoat, Pewtershmitz, Ricotez, ShiftyEyesShady, Skie, TankNut, Thatguythere03, Uhangi, Veyveyr<br></font>
 			<font size='2'><b>Mappers:</b> Prophed<br></font>
 			<font size='2'><b>Sounds:</b> Skie, Lasty/Vinyl<br></td></font>
 			<font size='2'><b>Thanks to:</b> /tg/Station 13, Baystation 12, /vg/station, NTstation, CDK Station devs, FacepunchStation, GoonStation devs, the original SpaceStation developers and Invisty for the title image.<br> Also a thanks to anybody who has contributed who is not listed here :( Ask to be added here on the forums/Discord.</font>
-			<font size='2' color='red'><b><br>Have a bug to report?</b> Visit our <a href="https://github.com/Rukofamicom/Royale-Station-13/issues">Issue Tracker</a>.<br></font>
+			<font size='2' color='red'><b><br>Have a bug to report?</b> Visit our <a href="https://github.com/Royale-Station-13/Royale-Station-13/issues">Issue Tracker</a>.<br></font>
 			<font size='2'>Please ensure that the bug has not already been reported and use the template provided!</b></a></u>.</font>
 		</td>
 	</tr>

--- a/html/templates/header.html
+++ b/html/templates/header.html
@@ -23,10 +23,10 @@
 <table align='center' class="top">
 	<tr>
 		<td valign='top'>
-			<div align='center'><font size='3'><b>BeeStation 13</b></font></div>
+			<div align='center'><font size='3'><b>Royale Station 13</b></font></div>
 
-			<p><div align='center'><font size='3'><a href="https://beestation13.com/">Site</a> | <a href="https://beestation13.com/forum">Forum</a> | <a href="https://wiki.beestation13.com/">Wiki</a> | <a href="https://github.com/Rukofamicom/Royale-Station-13">Source</a></font></div></p>
-			<font size='2'><b>Join our Discord </b><a href=https://discord.gg/zUe34rs>Here!</a></font>
+			<p><div align='center'><font size='3'><a href="https://royalestation13.com/">Site</a> | <a href="https://wiki.beestation13.com/">Wiki</a> | <a href="https://github.com/Royale-Station-13/Royale-Station-13">Source</a></font></div></p>
+			<font size='2'><b>Join our Discord </b><a href=https://discord.gg/m5wTK9fxa3>Here!</a></font>
 			</td>
 	</tr>
 </table>
@@ -34,14 +34,14 @@
 <table align='center' class="top">
 	<tr>
 		<td valign='top'>
-			<font size='2'><b>Current Project Maintainers:</b> <a href='https://github.com/orgs/BeeStation/people'>-Click Here-</a><br></font>
-			<font size='2'><b>Currently Active GitHub contributor list:</b> <a href='https://github.com/Rukofamicom/Royale-Station-13/graphs/contributors'>-Click Here-</a><br></font>
+			<font size='2'><b>Current Project Maintainers:</b> <a href='https://github.com/orgs/Royale-Station-13/people'>-Click Here-</a><br></font>
+			<font size='2'><b>Currently Active GitHub contributor list:</b> <a href='https://github.com/Royale-Station-13/Royale-Station-13/graphs/contributors'>-Click Here-</a><br></font>
 			<font size='2'><b>Coders:</b> Agouri, Aranclanos, AzlanonPC, Cael_Aislinn, Carn, Cenrus, Cheridan, ConstantA, Crossedfall, CthulhuOnIce, Darem, Donkie, Doohl, DumpDavidson, Elo001, Errorage, Francinum, Fleure, Giacom, Ikarrus, Intigracy, Kor, MCterra, Malkevin, ManeaterMildred, Mark Suckerberg, Miauw, Mport, MrPerson, NEO, Nodrak, Noise, Noka, Numbers, Petethegoat, Polymorph, PowerfulBacon, Qwertyquerty, Rockdtben, ShadowH4nD, Sieve, Skie, St0rmC4st3r, SuperSayu, Superxpdude, TLE, Tastyfish, Uhangi, Urist McDorf, Yvar, ike709, muskets, rastaf0, trubble_bass, veryinky<br></font>
 			<font size='2'><b>Spriters:</b> Agouri, Ausops, AzlanonPC, Cheridan, CruazyGuest, Deeaych, Deuryn, Firecage, Kor, Matty406, Microwave, Naevi, Nienhaus2, Petethegoat, Pewtershmitz, Ricotez, ShiftyEyesShady, Skie, TankNut, Thatguythere03, Uhangi, Veyveyr<br></font>
 			<font size='2'><b>Mappers:</b> Prophed<br></font>
 			<font size='2'><b>Sounds:</b> Skie, Lasty/Vinyl<br></td></font>
 			<font size='2'><b>Thanks to:</b> /tg/Station 13, Baystation 12, /vg/station, NTstation, CDK Station devs, FacepunchStation, GoonStation devs, the original SpaceStation developers and Invisty for the title image.<br> Also a thanks to anybody who has contributed who is not listed here :( Ask to be added here on the forums/Discord.</font>
-			<font size='2' color='red'><b><br>Have a bug to report?</b> Visit our <a href="https://github.com/Rukofamicom/Royale-Station-13/issues">Issue Tracker</a>.<br></font>
+			<font size='2' color='red'><b><br>Have a bug to report?</b> Visit our <a href="https://github.com/Royale-Station-13/Royale-Station-13/issues">Issue Tracker</a>.<br></font>
 			<font size='2'>Please ensure that the bug has not already been reported and use the template provided!</b></a></u>.</font>
 		</td>
 	</tr>

--- a/tools/fetchContributors.py
+++ b/tools/fetchContributors.py
@@ -15,7 +15,7 @@ blacklist = [
 parser = argparse.ArgumentParser()
 
 parser.add_argument('--pages', type=int, default=15, help='The program looks at the past 100*pages commits. Default: 15')
-parser.add_argument('--repo',  type=str, default=None, help='author/repo e.g. Rukofamicom/Royale-Station-13')
+parser.add_argument('--repo',  type=str, default=None, help='author/repo e.g. Royale-Station-13/Royale-Station-13')
 parser.add_argument('--token', type=str, default=None, help="Github personal access token (optional)")
 
 args_ns = parser.parse_args()


### PR DESCRIPTION
Repaths to new repo path and adds the website link. Fixes some other shoddy changelog links / title